### PR TITLE
Separate UI and game coroutines: add RunUiCoroutine/RunGameCoroutine and ProcessIgnorePause scheduler

### DIFF
--- a/GFramework.Godot/coroutine/Segment.cs
+++ b/GFramework.Godot/coroutine/Segment.cs
@@ -6,9 +6,14 @@
 public enum Segment
 {
     /// <summary>
-    ///     普通处理阶段，在每一帧的常规处理过程中执行
+    ///     普通处理阶段，在每一帧的常规处理过程中执行（默认用于游戏级协程）
     /// </summary>
     Process,
+
+    /// <summary>
+    ///     在暂停状态下仍然执行的处理阶段，适合暂停菜单等需要继续更新的UI级协程
+    /// </summary>
+    ProcessIgnorePause,
 
     /// <summary>
     ///     物理处理阶段，在物理更新循环中执行，通常用于需要与物理引擎同步的操作


### PR DESCRIPTION
### Motivation
- Provide two clear coroutine semantics: a UI-level coroutine that continues while `SceneTree.Paused` and a game-level coroutine that is pause-aware. 
- Preserve original game pause behavior while enabling UI flows (e.g. pause menu) to keep updating.

### Description
- Add documentation to `Segment` and a new `Segment.ProcessIgnorePause` enum value for UI-level coroutines in `GFramework.Godot/coroutine/Segment.cs`.
- Add a dedicated scheduler and time source for the pause-ignoring process segment and initialize them in `Timing.InitializeSchedulers`.
- Make `Timing` run the normal process scheduler only when `GetTree().Paused` is false, always update the ignore-pause scheduler in `_Process`, and set `ProcessMode = ProcessModeEnum.Always` in `_Ready`.
- Add `RunGameCoroutine` and `RunUiCoroutine` helpers that call `RunCoroutine(..., Segment.Process)` and `RunCoroutine(..., Segment.ProcessIgnorePause)` respectively, and wire the new scheduler into `RunCoroutineOnInstance`, `PauseOnInstance`, `ResumeOnInstance`, `KillOnInstance`, `KillByTagOnInstance`, and `ClearOnInstance`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986899735c483309410845d4412b1a0)

## Summary by Sourcery

Introduce separate coroutine scheduling for game and UI flows with pause-aware and pause-ignoring processing segments.

New Features:
- Add a ProcessIgnorePause coroutine segment and associated scheduler/time source for coroutines that continue running while the scene tree is paused.
- Add RunGameCoroutine and RunUiCoroutine helpers to simplify starting pause-aware and pause-ignoring coroutines.

Enhancements:
- Update Timing to always process UI-level coroutines while conditionally updating game-level and deferred schedulers based on the scene pause state.
- Set the Timing node to always process so that UI-level coroutines can run regardless of scene pause.