### PR TITLE
Chore/update docs workflow 

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -5,7 +5,7 @@ name: Publish Docs
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 permissions:
   contents: read
   pages: write
@@ -17,6 +17,9 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    if: |
+      (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-'))
+      || (github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, '[release doc]'))
     runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -31,24 +31,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # 2️⃣ 安装 Node.js
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      # 2️⃣ 安装 Bun.js
+      - uses: oven-sh/setup-bun@v2
         with:
-          node-version: 20
-          cache: 'npm'
-
+          bun-version: latest
       # 3️⃣ 安装依赖
       - name: Install Dependencies
         run: |
           cd docs
-          npm install
-
+          bun install
       # 4️⃣ 构建 VitePress
       - name: Build VitePress
         run: |
           cd docs
-          npm run build
+          bun run build
 
       # 5️⃣ 上传构建产物
       - name: Upload Pages Artifact

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -19,7 +19,7 @@ jobs:
   build-and-deploy:
     if: |
       (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-'))
-      || (github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, '[release doc]'))
+      || contains(github.event.head_commit.message, '[release doc]'))
     runs-on: ubuntu-latest
 
     environment:
@@ -34,7 +34,7 @@ jobs:
       # 2️⃣ 安装 Bun.js
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 2.1.x
       # 3️⃣ 安装依赖
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Restrict the docs publish workflow to version tags starting with 'v' and gated main-branch commits, and migrate the build steps from Node/npm to Bun.