### PR TITLE
chore(workflow): 添加手动触发文档发布工作流功能

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,6 +6,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
- 在 GitHub Actions 工作流配置中添加 workflow_dispatch 触发器
- 允许通过 GitHub 界面手动运行文档发布流程
- 保留原有的 push 和 tags 触发规则
- 维持现有的权限设置不变

## Summary by Sourcery

Build:
- Add workflow_dispatch trigger to the docs publish GitHub Actions workflow to allow manual runs from the UI.