### PR TITLE
feat(state): 实现异步状态基类的同步方法限制

### DIFF
--- a/GFramework.Core.Abstractions/state/IAsyncState.cs
+++ b/GFramework.Core.Abstractions/state/IAsyncState.cs
@@ -16,7 +16,7 @@ namespace GFramework.Core.Abstractions.state;
 /// <summary>
 ///     异步状态机状态接口，定义了状态的异步行为和转换规则
 /// </summary>
-public interface IAsyncState
+public interface IAsyncState : IState
 {
     /// <summary>
     ///     当状态被激活进入时异步调用

--- a/GFramework.Core/state/AsyncContextAwareStateBase.cs
+++ b/GFramework.Core/state/AsyncContextAwareStateBase.cs
@@ -62,6 +62,39 @@ public class AsyncContextAwareStateBase : IAsyncState, IContextAware, IDisposabl
     }
 
     /// <summary>
+    ///     同步进入状态（不推荐使用）
+    ///     异步状态应该使用 OnEnterAsync 方法
+    /// </summary>
+    /// <exception cref="NotSupportedException">异步状态不支持同步操作</exception>
+    public virtual void OnEnter(IState? from)
+    {
+        throw new NotSupportedException(
+            $"This is an async state ({GetType().Name}). Use OnEnterAsync instead of OnEnter.");
+    }
+
+    /// <summary>
+    ///     同步退出状态（不推荐使用）
+    ///     异步状态应该使用 OnExitAsync 方法
+    /// </summary>
+    /// <exception cref="NotSupportedException">异步状态不支持同步操作</exception>
+    public virtual void OnExit(IState? to)
+    {
+        throw new NotSupportedException(
+            $"This is an async state ({GetType().Name}). Use OnExitAsync instead of OnExit.");
+    }
+
+    /// <summary>
+    ///     同步判断是否可以转换（不推荐使用）
+    ///     异步状态应该使用 CanTransitionToAsync 方法
+    /// </summary>
+    /// <exception cref="NotSupportedException">异步状态不支持同步操作</exception>
+    public virtual bool CanTransitionTo(IState target)
+    {
+        throw new NotSupportedException(
+            $"This is an async state ({GetType().Name}). Use CanTransitionToAsync instead of CanTransitionTo.");
+    }
+
+    /// <summary>
     ///     设置架构上下文
     /// </summary>
     /// <param name="context">架构上下文实例</param>


### PR DESCRIPTION
- 为 AsyncContextAwareStateBase 添加同步方法异常抛出机制
- 禁止在异步状态中使用 OnEnter、OnExit 和 CanTransitionTo 同步方法
- 提供清晰的错误提示引导使用对应的异步方法
- 修复 StateMachine 中的状态转换逻辑确保线程安全
- 更新 IAsyncState 接口继承 IState 接口统一状态管理

## Summary by Sourcery

Restrict synchronous APIs on async states and improve async state machine safety and consistency.

New Features:
- Add explicit NotSupportedException-throwing implementations of synchronous lifecycle and transition methods on async state base types to guide callers toward async equivalents.
- Update the async state interface to inherit from the base state interface for unified state management.

Bug Fixes:
- Fix a race condition in the async state machine transition logic by taking a snapshot of the current state under lock before performing async validation and callbacks.