### PR TITLE
chore(workflow): 更新自动标签工作流配置

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -5,7 +5,7 @@ on:
     workflows: ["CI - Build & Test"]
     types:
       - completed
-
+  workflow_dispatch:
 concurrency:
   group: auto-tag-main
   cancel-in-progress: false
@@ -13,10 +13,12 @@ concurrency:
 jobs:
   auto-tag:
     if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main'&&
-      contains(github.event.workflow_run.head_commit.message, '[release ci]')
-
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       contains(github.event.workflow_run.head_commit.message, '[release ci]'))
+      ||
+      (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -13,12 +13,17 @@ concurrency:
 jobs:
   auto-tag:
     if: >
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'main' &&
-       contains(github.event.workflow_run.head_commit.message, '[release ci]'))
-      ||
-      (github.event_name == 'workflow_dispatch')
+      github.ref == 'refs/heads/main' &&
+      (
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          contains(github.event.workflow_run.head_commit.message, '[release ci]')
+        )
+        ||
+        github.event_name == 'workflow_dispatch'
+      )
+    
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
- 修改触发条件以支持手动调度
- 重构条件判断逻辑提高可读性
- 保持原有自动化标签功能不变
- 添加对 workflow_dispatch 事件的支持

## Summary by Sourcery

Update the auto-tag GitHub Actions workflow to support both automatic and manual triggering while preserving existing behavior.

CI:
- Allow manually dispatching the auto-tag workflow via workflow_dispatch in addition to workflow_run.
- Refine the job-level conditional to clearly separate workflow_run-based execution from manual dispatch execution.