### PR TITLE
feat(godot): 添加协程扩展功能支持Mediator模式

### DIFF
--- a/GFramework.Core.Tests/mediator/MediatorAdvancedFeaturesTests.cs
+++ b/GFramework.Core.Tests/mediator/MediatorAdvancedFeaturesTests.cs
@@ -47,12 +47,6 @@ public class MediatorAdvancedFeaturesTests
     private ArchitectureContext? _context;
     private MicrosoftDiContainer? _container;
 
-    [Test]
-    public async Task Request_With_Logging_Behavior_Should_Log_Correctly()
-    {
-        // 由于我们没有实现实际的日志行为，这个测试暂时跳过
-        Assert.Ignore("Logging behavior not implemented in this test setup");
-    }
 
     [Test]
     public async Task Request_With_Validation_Behavior_Should_Validate_Input()

--- a/GFramework.Godot/coroutine/ContextAwareCoroutineExtensions.cs
+++ b/GFramework.Godot/coroutine/ContextAwareCoroutineExtensions.cs
@@ -1,0 +1,107 @@
+﻿using GFramework.Core.Abstractions.rule;
+using GFramework.Core.coroutine;
+using GFramework.Core.coroutine.extensions;
+using GFramework.Core.extensions;
+using Mediator;
+
+namespace GFramework.Godot.coroutine;
+
+/// <summary>
+///     提供协程相关的扩展方法，用于简化协程的启动和管理。
+/// </summary>
+public static class ContextAwareCoroutineExtensions
+{
+    /// <summary>
+    /// 发送命令并直接以协程方式运行（无返回值）
+    /// </summary>
+    /// <param name="contextAware">上下文感知对象，用于发送命令</param>
+    /// <param name="command">要发送的命令对象</param>
+    /// <param name="segment">协程运行的时间段，默认为 Process</param>
+    /// <param name="tag">协程的标签，可用于标识或分组协程</param>
+    /// <param name="cancellationToken">用于取消操作的令牌</param>
+    /// <returns>返回协程的句柄，可用于后续操作（如停止协程）</returns>
+    public static CoroutineHandle RunCommandCoroutine(
+        this IContextAware contextAware,
+        ICommand command,
+        Segment segment = Segment.Process,
+        string? tag = null,
+        CancellationToken cancellationToken = default)
+    {
+        return contextAware
+            .SendCommandAsync(command, cancellationToken)
+            .AsTask()
+            .ToCoroutineEnumerator()
+            .RunCoroutine(segment, tag);
+    }
+
+    /// <summary>
+    /// 发送命令并直接以协程方式运行（带返回值）
+    /// </summary>
+    /// <typeparam name="TResponse">命令返回值的类型</typeparam>
+    /// <param name="contextAware">上下文感知对象，用于发送命令</param>
+    /// <param name="command">要发送的命令对象</param>
+    /// <param name="segment">协程运行的时间段，默认为 Process</param>
+    /// <param name="tag">协程的标签，可用于标识或分组协程</param>
+    /// <param name="cancellationToken">用于取消操作的令牌</param>
+    /// <returns>返回协程的句柄，可用于后续操作（如停止协程）</returns>
+    public static CoroutineHandle RunCommandCoroutine<TResponse>(
+        this IContextAware contextAware,
+        ICommand<TResponse> command,
+        Segment segment = Segment.Process,
+        string? tag = null,
+        CancellationToken cancellationToken = default)
+    {
+        return contextAware
+            .SendCommandAsync(command, cancellationToken)
+            .AsTask()
+            .ToCoroutineEnumerator()
+            .RunCoroutine(segment, tag);
+    }
+
+    /// <summary>
+    /// 发送查询并直接以协程方式运行（带返回值）
+    /// </summary>
+    /// <typeparam name="TResponse">查询返回值的类型</typeparam>
+    /// <param name="contextAware">上下文感知对象，用于发送查询</param>
+    /// <param name="query">要发送的查询对象</param>
+    /// <param name="segment">协程运行的时间段，默认为 Process</param>
+    /// <param name="tag">协程的标签，可用于标识或分组协程</param>
+    /// <param name="cancellationToken">用于取消操作的令牌</param>
+    /// <returns>返回协程的句柄，可用于后续操作（如停止协程）</returns>
+    public static CoroutineHandle RunQueryCoroutine<TResponse>(
+        this IContextAware contextAware,
+        IQuery<TResponse> query,
+        Segment segment = Segment.Process,
+        string? tag = null,
+        CancellationToken cancellationToken = default)
+    {
+        return contextAware
+            .SendQueryAsync(query, cancellationToken)
+            .AsTask()
+            .ToCoroutineEnumerator()
+            .RunCoroutine(segment, tag);
+    }
+
+    /// <summary>
+    /// 发布通知并直接以协程方式运行
+    /// </summary>
+    /// <param name="contextAware">上下文感知对象，用于发布通知</param>
+    /// <param name="notification">要发布的通知对象</param>
+    /// <param name="segment">协程运行的时间段，默认为 Process</param>
+    /// <param name="tag">协程的标签，可用于标识或分组协程</param>
+    /// <param name="cancellationToken">用于取消操作的令牌</param>
+    /// <returns>返回协程的句柄，可用于后续操作（如停止协程）</returns>
+    public static CoroutineHandle RunPublishCoroutine(
+        this IContextAware contextAware,
+        INotification notification,
+        Segment segment = Segment.Process,
+        string? tag = null,
+        CancellationToken cancellationToken = default)
+    {
+        return contextAware
+            .PublishEventAsync(notification, cancellationToken)
+            .AsTask()
+            .ToCoroutineEnumerator()
+            .RunCoroutine(segment, tag);
+    }
+}

--- a/GFramework.Godot/coroutine/CoroutineNodeExtensions.cs
+++ b/GFramework.Godot/coroutine/CoroutineNodeExtensions.cs
@@ -1,37 +1,47 @@
-﻿using GFramework.Core.Abstractions.coroutine;
+﻿// Copyright (c) 2026 GeWuYou
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GFramework.Core.Abstractions.coroutine;
 using GFramework.Core.coroutine;
 using Godot;
 
 namespace GFramework.Godot.coroutine;
 
 /// <summary>
-///     提供协程相关的扩展方法，用于简化协程的启动和管理。
+/// 提供协程相关的扩展方法，用于在Godot环境中管理协程的生命周期。
 /// </summary>
-public static class CoroutineExtensions
+public static class CoroutineNodeExtensions
 {
     /// <summary>
-    ///     启动协程的扩展方法。
+    /// 启动协程的扩展方法。
     /// </summary>
     /// <param name="coroutine">要启动的协程枚举器。</param>
     /// <param name="segment">协程运行的时间段，默认为 Process。</param>
     /// <param name="tag">协程的标签，可用于标识或分组协程。</param>
     /// <returns>返回协程的句柄，可用于后续操作（如停止协程）。</returns>
-    public static CoroutineHandle RunCoroutine(
-        this IEnumerator<IYieldInstruction> coroutine,
-        Segment segment = Segment.Process,
-        string? tag = null)
+    public static CoroutineHandle RunCoroutine(this IEnumerator<IYieldInstruction> coroutine,
+        Segment segment = Segment.Process, string? tag = null)
     {
         return Timing.RunCoroutine(coroutine, segment, tag);
     }
 
     /// <summary>
-    ///     让协程在指定节点被销毁时自动取消。
+    /// 让协程在指定节点被销毁时自动取消。
     /// </summary>
-    /// <param name="coroutine">要执行的协程枚举器。</param>
+    /// <param name="coroutine">要包装的协程枚举器。</param>
     /// <param name="node">用于检查是否存活的节点。</param>
     /// <returns>包装后的协程枚举器。</returns>
-    public static IEnumerator<IYieldInstruction> CancelWith(
-        this IEnumerator<IYieldInstruction> coroutine,
+    public static IEnumerator<IYieldInstruction> CancelWith(this IEnumerator<IYieldInstruction> coroutine,
         Node node)
     {
         while (Timing.IsNodeAlive(node) && coroutine.MoveNext())
@@ -39,16 +49,14 @@ public static class CoroutineExtensions
     }
 
     /// <summary>
-    ///     让协程在任一节点被销毁时自动取消。
+    /// 让协程在任一节点被销毁时自动取消。
     /// </summary>
-    /// <param name="coroutine">要执行的协程枚举器。</param>
+    /// <param name="coroutine">要包装的协程枚举器。</param>
     /// <param name="node1">第一个用于检查是否存活的节点。</param>
     /// <param name="node2">第二个用于检查是否存活的节点。</param>
     /// <returns>包装后的协程枚举器。</returns>
-    public static IEnumerator<IYieldInstruction> CancelWith(
-        this IEnumerator<IYieldInstruction> coroutine,
-        Node node1,
-        Node node2)
+    public static IEnumerator<IYieldInstruction> CancelWith(this IEnumerator<IYieldInstruction> coroutine,
+        Node node1, Node node2)
     {
         while (Timing.IsNodeAlive(node1) &&
                Timing.IsNodeAlive(node2) &&
@@ -57,26 +65,25 @@ public static class CoroutineExtensions
     }
 
     /// <summary>
-    ///     让协程在多个节点都被销毁时自动取消。
+    /// 让协程在多个节点都被销毁时自动取消。
     /// </summary>
-    /// <param name="coroutine">要执行的协程枚举器。</param>
+    /// <param name="coroutine">要包装的协程枚举器。</param>
     /// <param name="nodes">用于检查是否存活的节点数组。</param>
     /// <returns>包装后的协程枚举器。</returns>
-    public static IEnumerator<IYieldInstruction> CancelWith(
-        this IEnumerator<IYieldInstruction> coroutine,
+    public static IEnumerator<IYieldInstruction> CancelWith(this IEnumerator<IYieldInstruction> coroutine,
         params Node[] nodes)
     {
         // 持续执行协程直到任一节点被销毁或协程执行完毕
-        while (AllNodesAlive(nodes) && coroutine.MoveNext())
+        while (nodes.AllNodesAlive() && coroutine.MoveNext())
             yield return coroutine.Current;
     }
 
     /// <summary>
-    ///     检查所有节点是否都处于存活状态。
+    /// 检查所有节点是否都处于存活状态。
     /// </summary>
     /// <param name="nodes">要检查的节点数组。</param>
     /// <returns>如果所有节点都存活则返回 true，否则返回 false。</returns>
-    private static bool AllNodesAlive(Node[] nodes)
+    private static bool AllNodesAlive(this Node[] nodes)
     {
         return nodes.All(Timing.IsNodeAlive);
     }


### PR DESCRIPTION
- 新增ContextAwareCoroutineExtensions类，提供IContextAware接口的协程扩展方法
- 实现RunCommandCoroutine、RunQueryCoroutine和RunPublishCoroutine方法
- 将原有CoroutineExtensions重命名为CoroutineNodeExtensions并迁移相关功能
- 添加文件头版权信息到新的协程扩展类
- 重构协程生命周期管理方法，包括RunCoroutine和CancelWith系列方法
- 移除测试文件中关于日志行为的占位测试用例

## Summary by Sourcery

Add context-aware coroutine extensions for Mediator integration and refine Godot coroutine lifecycle utilities.

New Features:
- Introduce context-aware coroutine extension methods to run Mediator commands, queries, and notifications as coroutines.

Enhancements:
- Rename and scope existing coroutine utilities to CoroutineNodeExtensions for Godot node-based lifecycle management.
- Add license header and minor improvements to coroutine cancellation helpers using node liveness checks.

Tests:
- Remove obsolete placeholder test for unimplemented logging behavior in Mediator advanced feature tests.