### PR TITLE
refactor(cqrs): 重构CQRS架构基础组件并新增核心基类

### DIFF
--- a/GFramework.Core.Abstractions/cqrs/IInput.cs
+++ b/GFramework.Core.Abstractions/cqrs/IInput.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) 2026 GeWuYou
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace GFramework.Core.Abstractions.cqrs;
+
+/// <summary>
+/// 表示输入数据的标记接口。
+/// 该接口用于标识各类CQRS模式中的输入参数类型。
+/// </summary>
+public interface IInput;

--- a/GFramework.Core.Abstractions/cqrs/command/ICommandInput.cs
+++ b/GFramework.Core.Abstractions/cqrs/command/ICommandInput.cs
@@ -1,7 +1,7 @@
-﻿namespace GFramework.Core.Abstractions.command;
+﻿namespace GFramework.Core.Abstractions.cqrs.command;
 
 /// <summary>
 ///     命令输入接口，定义命令模式中输入数据的契约
 ///     该接口作为标记接口使用，不包含任何成员定义
 /// </summary>
-public interface ICommandInput;
+public interface ICommandInput : IInput;

--- a/GFramework.Core.Abstractions/cqrs/notification/INotificationInput.cs
+++ b/GFramework.Core.Abstractions/cqrs/notification/INotificationInput.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) 2026 GeWuYou
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace GFramework.Core.Abstractions.cqrs.notification;
+
+/// <summary>
+/// 表示通知输入数据的标记接口。
+/// 该接口继承自 IInput，用于标识CQRS模式中通知类型的输入参数。
+/// </summary>
+public interface INotificationInput : IInput;

--- a/GFramework.Core.Abstractions/cqrs/query/IQueryInput.cs
+++ b/GFramework.Core.Abstractions/cqrs/query/IQueryInput.cs
@@ -1,6 +1,6 @@
-﻿namespace GFramework.Core.Abstractions.query;
+﻿namespace GFramework.Core.Abstractions.cqrs.query;
 
 /// <summary>
 ///     查询输入接口，定义了查询操作的输入规范
 /// </summary>
-public interface IQueryInput;
+public interface IQueryInput : IInput;

--- a/GFramework.Core.Abstractions/cqrs/request/IRequestInput.cs
+++ b/GFramework.Core.Abstractions/cqrs/request/IRequestInput.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) 2026 GeWuYou
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace GFramework.Core.Abstractions.cqrs.request;
+
+/// <summary>
+/// 表示请求输入数据的标记接口。
+/// 该接口继承自 IInput，用于标识CQRS模式中请求类型的输入参数。
+/// </summary>
+public interface IRequestInput : IInput;

--- a/GFramework.Core.Tests/command/AbstractAsyncCommandTests.cs
+++ b/GFramework.Core.Tests/command/AbstractAsyncCommandTests.cs
@@ -1,4 +1,5 @@
 using GFramework.Core.Abstractions.command;
+using GFramework.Core.Abstractions.cqrs.command;
 using GFramework.Core.Abstractions.rule;
 using GFramework.Core.architecture;
 using GFramework.Core.command;

--- a/GFramework.Core.Tests/command/CommandExecutorTests.cs
+++ b/GFramework.Core.Tests/command/CommandExecutorTests.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.command;
+using GFramework.Core.Abstractions.cqrs.command;
 using GFramework.Core.command;
 using NUnit.Framework;
 

--- a/GFramework.Core.Tests/query/AbstractAsyncQueryTests.cs
+++ b/GFramework.Core.Tests/query/AbstractAsyncQueryTests.cs
@@ -1,3 +1,4 @@
+using GFramework.Core.Abstractions.cqrs.query;
 using GFramework.Core.Abstractions.query;
 using GFramework.Core.Abstractions.rule;
 using GFramework.Core.architecture;

--- a/GFramework.Core.Tests/query/AsyncQueryExecutorTests.cs
+++ b/GFramework.Core.Tests/query/AsyncQueryExecutorTests.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.query;
+using GFramework.Core.Abstractions.cqrs.query;
 using GFramework.Core.query;
 using NUnit.Framework;
 

--- a/GFramework.Core.Tests/query/QueryExecutorTests.cs
+++ b/GFramework.Core.Tests/query/QueryExecutorTests.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.query;
+using GFramework.Core.Abstractions.cqrs.query;
 using GFramework.Core.query;
 using NUnit.Framework;
 

--- a/GFramework.Core/command/AbstractAsyncCommandWithInput.cs
+++ b/GFramework.Core/command/AbstractAsyncCommandWithInput.cs
@@ -1,4 +1,5 @@
 ﻿using GFramework.Core.Abstractions.command;
+using GFramework.Core.Abstractions.cqrs.command;
 using GFramework.Core.rule;
 
 namespace GFramework.Core.command;

--- a/GFramework.Core/command/AbstractAsyncCommandWithResult.cs
+++ b/GFramework.Core/command/AbstractAsyncCommandWithResult.cs
@@ -1,4 +1,5 @@
 ﻿using GFramework.Core.Abstractions.command;
+using GFramework.Core.Abstractions.cqrs.command;
 using GFramework.Core.rule;
 
 namespace GFramework.Core.command;

--- a/GFramework.Core/command/AbstractCommandWithInput.cs
+++ b/GFramework.Core/command/AbstractCommandWithInput.cs
@@ -1,4 +1,5 @@
 ﻿using GFramework.Core.Abstractions.command;
+using GFramework.Core.Abstractions.cqrs.command;
 using GFramework.Core.rule;
 
 namespace GFramework.Core.command;

--- a/GFramework.Core/command/AbstractCommandWithResult.cs
+++ b/GFramework.Core/command/AbstractCommandWithResult.cs
@@ -1,4 +1,5 @@
 ﻿using GFramework.Core.Abstractions.command;
+using GFramework.Core.Abstractions.cqrs.command;
 using GFramework.Core.rule;
 
 namespace GFramework.Core.command;

--- a/GFramework.Core/command/EmptyCommandInput.cs
+++ b/GFramework.Core/command/EmptyCommandInput.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.command;
+using GFramework.Core.Abstractions.cqrs.command;
 
 namespace GFramework.Core.command;
 

--- a/GFramework.Core/cqrs/command/CommandBase.cs
+++ b/GFramework.Core/cqrs/command/CommandBase.cs
@@ -23,7 +23,7 @@ namespace GFramework.Core.cqrs.command;
 /// <typeparam name="TInput">命令输入数据的类型</typeparam>
 /// <typeparam name="TResponse">命令执行后返回结果的类型</typeparam>
 /// <param name="input">命令执行所需的输入数据</param>
-public class CommandBase<TInput, TResponse>(TInput input) : ICommand<TResponse> where TInput : ICommandInput
+public abstract class CommandBase<TInput, TResponse>(TInput input) : ICommand<TResponse> where TInput : ICommandInput
 {
     /// <summary>
     /// 获取命令的输入数据。

--- a/GFramework.Core/cqrs/command/CommandBase.cs
+++ b/GFramework.Core/cqrs/command/CommandBase.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2026 GeWuYou
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GFramework.Core.Abstractions.cqrs.command;
+using Mediator;
+
+namespace GFramework.Core.cqrs.command;
+
+/// <summary>
+/// 表示一个基础命令类，用于处理带有输入和响应的命令模式实现。
+/// 该类实现了 ICommand&lt;TResponse&gt; 接口，提供了通用的命令结构。
+/// </summary>
+/// <typeparam name="TInput">命令输入数据的类型</typeparam>
+/// <typeparam name="TResponse">命令执行后返回结果的类型</typeparam>
+/// <param name="input">命令执行所需的输入数据</param>
+public class CommandBase<TInput, TResponse>(TInput input) : ICommand<TResponse> where TInput : ICommandInput
+{
+    /// <summary>
+    /// 获取命令的输入数据。
+    /// </summary>
+    public TInput Input => input;
+}

--- a/GFramework.Core/cqrs/notification/NotificationBase.cs
+++ b/GFramework.Core/cqrs/notification/NotificationBase.cs
@@ -22,7 +22,7 @@ namespace GFramework.Core.cqrs.notification;
 /// </summary>
 /// <typeparam name="TInput">通知输入数据的类型，必须实现 INotificationInput 接口</typeparam>
 /// <param name="input">通知执行所需的输入数据</param>
-public class NotificationBase<TInput>(TInput input) : INotification where TInput : INotificationInput
+public abstract class NotificationBase<TInput>(TInput input) : INotification where TInput : INotificationInput
 {
     /// <summary>
     /// 获取通知的输入数据。

--- a/GFramework.Core/cqrs/notification/NotificationBase.cs
+++ b/GFramework.Core/cqrs/notification/NotificationBase.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2026 GeWuYou
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GFramework.Core.Abstractions.cqrs.notification;
+using Mediator;
+
+namespace GFramework.Core.cqrs.notification;
+
+/// <summary>
+/// 表示一个基础通知类，用于处理带有输入的通知模式实现。
+/// 该类实现了 INotification 接口，提供了通用的通知结构。
+/// </summary>
+/// <typeparam name="TInput">通知输入数据的类型，必须实现 INotificationInput 接口</typeparam>
+/// <param name="input">通知执行所需的输入数据</param>
+public class NotificationBase<TInput>(TInput input) : INotification where TInput : INotificationInput
+{
+    /// <summary>
+    /// 获取通知的输入数据。
+    /// </summary>
+    public TInput Input => input;
+}

--- a/GFramework.Core/cqrs/query/QueryBase.cs
+++ b/GFramework.Core/cqrs/query/QueryBase.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2026 GeWuYou
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GFramework.Core.Abstractions.cqrs.query;
+using Mediator;
+
+namespace GFramework.Core.cqrs.query;
+
+/// <summary>
+/// 表示一个基础查询类，用于处理带有输入和响应的查询模式实现。
+/// 该类继承自 Mediator.IQuery&lt;TResponse&gt; 接口，提供了通用的查询结构。
+/// </summary>
+/// <typeparam name="TInput">查询输入数据的类型，必须实现 IQueryInput 接口</typeparam>
+/// <typeparam name="TResponse">查询执行后返回结果的类型</typeparam>
+/// <param name="input">查询执行所需的输入数据</param>
+public class QueryBase<TInput, TResponse>(TInput input) : IQuery<TResponse> where TInput : IQueryInput
+{
+    /// <summary>
+    /// 获取查询的输入数据。
+    /// </summary>
+    public TInput Input => input;
+}

--- a/GFramework.Core/cqrs/query/QueryBase.cs
+++ b/GFramework.Core/cqrs/query/QueryBase.cs
@@ -23,7 +23,7 @@ namespace GFramework.Core.cqrs.query;
 /// <typeparam name="TInput">查询输入数据的类型，必须实现 IQueryInput 接口</typeparam>
 /// <typeparam name="TResponse">查询执行后返回结果的类型</typeparam>
 /// <param name="input">查询执行所需的输入数据</param>
-public class QueryBase<TInput, TResponse>(TInput input) : IQuery<TResponse> where TInput : IQueryInput
+public abstract class QueryBase<TInput, TResponse>(TInput input) : IQuery<TResponse> where TInput : IQueryInput
 {
     /// <summary>
     /// 获取查询的输入数据。

--- a/GFramework.Core/cqrs/request/RequestBase.cs
+++ b/GFramework.Core/cqrs/request/RequestBase.cs
@@ -23,7 +23,7 @@ namespace GFramework.Core.cqrs.request;
 /// <typeparam name="TInput">请求输入数据的类型，必须实现 IRequestInput 接口</typeparam>
 /// <typeparam name="TResponse">请求执行后返回结果的类型</typeparam>
 /// <param name="input">请求执行所需的输入数据</param>
-public class RequestBase<TInput, TResponse>(TInput input) : IRequest<TResponse> where TInput : IRequestInput
+public abstract class RequestBase<TInput, TResponse>(TInput input) : IRequest<TResponse> where TInput : IRequestInput
 {
     /// <summary>
     /// 获取请求的输入数据。

--- a/GFramework.Core/cqrs/request/RequestBase.cs
+++ b/GFramework.Core/cqrs/request/RequestBase.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2026 GeWuYou
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GFramework.Core.Abstractions.cqrs.request;
+using Mediator;
+
+namespace GFramework.Core.cqrs.request;
+
+/// <summary>
+/// 表示一个基础请求类，用于处理带有输入和响应的请求模式实现。
+/// 该类实现了 IRequest&lt;TResponse&gt; 接口，提供了通用的请求结构。
+/// </summary>
+/// <typeparam name="TInput">请求输入数据的类型，必须实现 IRequestInput 接口</typeparam>
+/// <typeparam name="TResponse">请求执行后返回结果的类型</typeparam>
+/// <param name="input">请求执行所需的输入数据</param>
+public class RequestBase<TInput, TResponse>(TInput input) : IRequest<TResponse> where TInput : IRequestInput
+{
+    /// <summary>
+    /// 获取请求的输入数据。
+    /// </summary>
+    public TInput Input => input;
+}

--- a/GFramework.Core/query/AbstractAsyncQueryWithResult.cs
+++ b/GFramework.Core/query/AbstractAsyncQueryWithResult.cs
@@ -1,4 +1,5 @@
-﻿using GFramework.Core.Abstractions.query;
+﻿using GFramework.Core.Abstractions.cqrs.query;
+using GFramework.Core.Abstractions.query;
 using GFramework.Core.rule;
 
 namespace GFramework.Core.query;

--- a/GFramework.Core/query/AbstractQueryWithResult.cs
+++ b/GFramework.Core/query/AbstractQueryWithResult.cs
@@ -1,4 +1,5 @@
-﻿using GFramework.Core.Abstractions.query;
+﻿using GFramework.Core.Abstractions.cqrs.query;
+using GFramework.Core.Abstractions.query;
 using GFramework.Core.rule;
 
 namespace GFramework.Core.query;

--- a/GFramework.Core/query/EmptyQueryInput.cs
+++ b/GFramework.Core/query/EmptyQueryInput.cs
@@ -1,4 +1,4 @@
-﻿using GFramework.Core.Abstractions.query;
+﻿using GFramework.Core.Abstractions.cqrs.query;
 
 namespace GFramework.Core.query;
 


### PR DESCRIPTION
- 将命令相关抽象接口从command目录迁移至cqrs.command目录
- 新增CommandBase、NotificationBase、QueryBase和RequestBase通用基类
- 统一所有CQRS组件的命名空间为GFramework.Core.Abstractions.cqrs
- 更新所有引用位置的using语句指向新的命名空间路径
- 为命令和查询输入接口添加IInput基接口继承
- 在测试文件中同步更新相关的引用路径修改

## Summary by Sourcery

Introduce shared CQRS input abstractions and base classes for commands, queries, notifications, and requests, and align namespaces and usages to the new cqrs structure.

New Features:
- Add generic CommandBase, QueryBase, NotificationBase, and RequestBase classes to standardize CQRS message handling.
- Introduce a common IInput marker interface and specialized IRequestInput and INotificationInput abstractions for CQRS inputs.

Enhancements:
- Move command and query input interfaces into the unified GFramework.Core.Abstractions.cqrs namespace and update all references accordingly.

Tests:
- Adjust existing command and query test fixtures to use the new CQRS abstractions namespaces.