### PR TITLE
Refactor/architecture remove query event sugar

### DIFF
--- a/GFramework.Core.Abstractions/architecture/IArchitecture.cs
+++ b/GFramework.Core.Abstractions/architecture/IArchitecture.cs
@@ -1,3 +1,4 @@
+using GFramework.Core.Abstractions.lifecycle;
 using GFramework.Core.Abstractions.model;
 using GFramework.Core.Abstractions.system;
 using GFramework.Core.Abstractions.utility;

--- a/GFramework.Core.Abstractions/architecture/IArchitectureContext.cs
+++ b/GFramework.Core.Abstractions/architecture/IArchitectureContext.cs
@@ -104,9 +104,9 @@ public interface IArchitectureContext
     /// [Mediator] 发送查询的同步版本（不推荐，仅用于兼容性）
     /// </summary>
     /// <typeparam name="TResponse">查询响应类型</typeparam>
-    /// <param name="command">要发送的查询对象</param>
+    /// <param name="query">要发送的查询对象</param>
     /// <returns>查询结果</returns>
-    TResponse SendQuery<TResponse>(Mediator.IQuery<TResponse> command);
+    TResponse SendQuery<TResponse>(Mediator.IQuery<TResponse> query);
 
     /// <summary>
     ///     异步发送一个查询请求
@@ -121,10 +121,10 @@ public interface IArchitectureContext
     /// 通过Mediator模式发送查询请求，支持取消操作
     /// </summary>
     /// <typeparam name="TResponse">查询响应类型</typeparam>
-    /// <param name="command">要发送的查询对象</param>
+    /// <param name="query">要发送的查询对象</param>
     /// <param name="cancellationToken">取消令牌，用于取消操作</param>
     /// <returns>包含查询结果的ValueTask</returns>
-    ValueTask<TResponse> SendQueryAsync<TResponse>(Mediator.IQuery<TResponse> command,
+    ValueTask<TResponse> SendQueryAsync<TResponse>(Mediator.IQuery<TResponse> query,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -199,20 +199,6 @@ public interface IArchitectureContext
         IRequest<TResponse> command,
         CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// 发送查询
-    /// </summary>
-    ValueTask<TResponse> QueryAsync<TResponse>(
-        IRequest<TResponse> query,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// 发布事件通知
-    /// </summary>
-    ValueTask PublishEventAsync<TNotification>(
-        TNotification notification,
-        CancellationToken cancellationToken = default)
-        where TNotification : INotification;
 
     /// <summary>
     ///     获取环境对象

--- a/GFramework.Core.Abstractions/lifecycle/IAsyncDestroyable.cs
+++ b/GFramework.Core.Abstractions/lifecycle/IAsyncDestroyable.cs
@@ -1,0 +1,13 @@
+namespace GFramework.Core.Abstractions.lifecycle;
+
+/// <summary>
+///     定义异步销毁接口，用于需要异步清理资源的组件
+/// </summary>
+public interface IAsyncDestroyable
+{
+    /// <summary>
+    ///     异步销毁方法，在组件关闭时调用
+    /// </summary>
+    /// <returns>表示异步销毁操作的任务</returns>
+    ValueTask DestroyAsync();
+}

--- a/GFramework.Core.Abstractions/lifecycle/IAsyncInitializable.cs
+++ b/GFramework.Core.Abstractions/lifecycle/IAsyncInitializable.cs
@@ -1,4 +1,4 @@
-﻿namespace GFramework.Core.Abstractions.architecture;
+namespace GFramework.Core.Abstractions.lifecycle;
 
 /// <summary>
 ///     定义异步初始化接口，用于需要异步初始化的组件或服务

--- a/GFramework.Core.Abstractions/lifecycle/IAsyncLifecycle.cs
+++ b/GFramework.Core.Abstractions/lifecycle/IAsyncLifecycle.cs
@@ -1,0 +1,8 @@
+namespace GFramework.Core.Abstractions.lifecycle;
+
+/// <summary>
+///     定义异步生命周期接口，组合了异步初始化和异步销毁
+/// </summary>
+public interface IAsyncLifecycle : IAsyncInitializable, IAsyncDestroyable
+{
+}

--- a/GFramework.Core.Abstractions/lifecycle/IDestroyable.cs
+++ b/GFramework.Core.Abstractions/lifecycle/IDestroyable.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///     可销毁接口，为需要资源清理的组件提供标准销毁能力
 /// </summary>
-public interface IDisposable
+public interface IDestroyable
 {
     /// <summary>
     ///     销毁组件并释放资源

--- a/GFramework.Core.Abstractions/lifecycle/ILifecycle.cs
+++ b/GFramework.Core.Abstractions/lifecycle/ILifecycle.cs
@@ -3,4 +3,4 @@
 /// <summary>
 ///     完整生命周期接口，组合了初始化和销毁能力
 /// </summary>
-public interface ILifecycle : IInitializable, IDisposable;
+public interface ILifecycle : IInitializable, IDestroyable;

--- a/GFramework.Core.Tests/architecture/ArchitectureServicesTests.cs
+++ b/GFramework.Core.Tests/architecture/ArchitectureServicesTests.cs
@@ -288,13 +288,13 @@ public class TestArchitectureContextV3 : IArchitectureContext
         throw new NotImplementedException();
     }
 
-    public ValueTask<TResponse> SendQueryAsync<TResponse>(Mediator.IQuery<TResponse> command,
+    public ValueTask<TResponse> SendQueryAsync<TResponse>(Mediator.IQuery<TResponse> query,
         CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public TResponse SendQuery<TResponse>(Mediator.IQuery<TResponse> command)
+    public TResponse SendQuery<TResponse>(Mediator.IQuery<TResponse> query)
     {
         throw new NotImplementedException();
     }
@@ -319,18 +319,6 @@ public class TestArchitectureContextV3 : IArchitectureContext
 
     public ValueTask<TResponse> SendAsync<TResponse>(IRequest<TResponse> command,
         CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ValueTask<TResponse> QueryAsync<TResponse>(IRequest<TResponse> query,
-        CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ValueTask PublishEventAsync<TNotification>(TNotification notification,
-        CancellationToken cancellationToken = default) where TNotification : INotification
     {
         throw new NotImplementedException();
     }
@@ -367,6 +355,18 @@ public class TestArchitectureContextV3 : IArchitectureContext
     public IEnvironment GetEnvironment()
     {
         return _environment;
+    }
+
+    public ValueTask<TResponse> QueryAsync<TResponse>(IRequest<TResponse> query,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask PublishEventAsync<TNotification>(TNotification notification,
+        CancellationToken cancellationToken = default) where TNotification : INotification
+    {
+        throw new NotImplementedException();
     }
 }
 

--- a/GFramework.Core.Tests/architecture/ArchitectureServicesTests.cs
+++ b/GFramework.Core.Tests/architecture/ArchitectureServicesTests.cs
@@ -356,18 +356,6 @@ public class TestArchitectureContextV3 : IArchitectureContext
     {
         return _environment;
     }
-
-    public ValueTask<TResponse> QueryAsync<TResponse>(IRequest<TResponse> query,
-        CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ValueTask PublishEventAsync<TNotification>(TNotification notification,
-        CancellationToken cancellationToken = default) where TNotification : INotification
-    {
-        throw new NotImplementedException();
-    }
 }
 
 #endregion

--- a/GFramework.Core.Tests/architecture/GameContextTests.cs
+++ b/GFramework.Core.Tests/architecture/GameContextTests.cs
@@ -451,16 +451,4 @@ public class TestArchitectureContext : IArchitectureContext
     {
         return Environment;
     }
-
-    public ValueTask<TResponse> QueryAsync<TResponse>(IRequest<TResponse> query,
-        CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ValueTask PublishEventAsync<TNotification>(TNotification notification,
-        CancellationToken cancellationToken = default) where TNotification : INotification
-    {
-        throw new NotImplementedException();
-    }
 }

--- a/GFramework.Core.Tests/architecture/GameContextTests.cs
+++ b/GFramework.Core.Tests/architecture/GameContextTests.cs
@@ -357,13 +357,13 @@ public class TestArchitectureContext : IArchitectureContext
         throw new NotImplementedException();
     }
 
-    public ValueTask<TResponse> SendQueryAsync<TResponse>(Mediator.IQuery<TResponse> command,
+    public ValueTask<TResponse> SendQueryAsync<TResponse>(Mediator.IQuery<TResponse> query,
         CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public TResponse SendQuery<TResponse>(Mediator.IQuery<TResponse> command)
+    public TResponse SendQuery<TResponse>(Mediator.IQuery<TResponse> query)
     {
         throw new NotImplementedException();
     }
@@ -388,18 +388,6 @@ public class TestArchitectureContext : IArchitectureContext
 
     public ValueTask<TResponse> SendAsync<TResponse>(IRequest<TResponse> command,
         CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ValueTask<TResponse> QueryAsync<TResponse>(IRequest<TResponse> query,
-        CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ValueTask PublishEventAsync<TNotification>(TNotification notification,
-        CancellationToken cancellationToken = default) where TNotification : INotification
     {
         throw new NotImplementedException();
     }
@@ -462,5 +450,17 @@ public class TestArchitectureContext : IArchitectureContext
     public IEnvironment GetEnvironment()
     {
         return Environment;
+    }
+
+    public ValueTask<TResponse> QueryAsync<TResponse>(IRequest<TResponse> query,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask PublishEventAsync<TNotification>(TNotification notification,
+        CancellationToken cancellationToken = default) where TNotification : INotification
+    {
+        throw new NotImplementedException();
     }
 }

--- a/GFramework.Core.Tests/mediator/MediatorComprehensiveTests.cs
+++ b/GFramework.Core.Tests/mediator/MediatorComprehensiveTests.cs
@@ -151,27 +151,6 @@ public class MediatorComprehensiveTests
     }
 
     [Test]
-    public async Task QueryAsync_Should_ReturnResult_When_Query_IsValid()
-    {
-        var testQuery = new TestQuery { QueryResult = "test result" };
-        var result = await _context!.QueryAsync(testQuery);
-
-        Assert.That(result, Is.EqualTo("test result"));
-    }
-
-    [Test]
-    public async Task PublishEventAsync_Should_PublishNotification_When_Notification_IsValid()
-    {
-        TestNotificationHandler.LastReceivedMessage = null;
-        var testNotification = new TestNotification { Message = "test event" };
-
-        await _context!.PublishEventAsync(testNotification);
-        await Task.Delay(100);
-
-        Assert.That(TestNotificationHandler.LastReceivedMessage, Is.EqualTo("test event"));
-    }
-
-    [Test]
     public void GetService_Should_Use_Cache()
     {
         var firstResult = _context!.GetService<IEventBus>();
@@ -288,21 +267,6 @@ public class MediatorComprehensiveTests
 
         // 验证数据被正确修改
         Assert.That(sharedData.Value, Is.EqualTo(30)); // 10 + 20
-    }
-
-    [Test]
-    public async Task Query_Caching_With_Mediator()
-    {
-        var cache = new Dictionary<string, string>();
-        var query1 = new TestCachingQuery { Key = "test1", Cache = cache };
-        var query2 = new TestCachingQuery { Key = "test1", Cache = cache }; // 相同key
-
-        var result1 = await _context!.QueryAsync(query1);
-        var result2 = await _context.QueryAsync(query2);
-
-        // 验证缓存生效（相同key返回相同结果）
-        Assert.That(result1, Is.EqualTo(result2));
-        Assert.That(cache.Count, Is.EqualTo(1)); // 只缓存了一次
     }
 
     [Test]

--- a/GFramework.Core.Tests/model/AsyncTestModel.cs
+++ b/GFramework.Core.Tests/model/AsyncTestModel.cs
@@ -1,5 +1,5 @@
-using GFramework.Core.Abstractions.architecture;
 using GFramework.Core.Abstractions.enums;
+using GFramework.Core.Abstractions.lifecycle;
 using GFramework.Core.model;
 
 namespace GFramework.Core.Tests.model;

--- a/GFramework.Core.Tests/state/StateMachineSystemTests.cs
+++ b/GFramework.Core.Tests/state/StateMachineSystemTests.cs
@@ -133,12 +133,12 @@ public class StateMachineSystemTests
     }
 
     /// <summary>
-    ///     测试Destroy方法不抛出异常
+    ///     测试DestroyAsync方法不抛出异常
     /// </summary>
     [Test]
-    public void Destroy_Should_Not_Throw_Exception()
+    public async Task DestroyAsync_Should_Not_Throw_Exception()
     {
-        Assert.That(() => _stateMachine!.Destroy(), Throws.Nothing);
+        Assert.That(async () => await _stateMachine!.DestroyAsync(), Throws.Nothing);
     }
 
     /// <summary>

--- a/GFramework.Core.Tests/system/AsyncTestSystem.cs
+++ b/GFramework.Core.Tests/system/AsyncTestSystem.cs
@@ -1,5 +1,6 @@
 ﻿using GFramework.Core.Abstractions.architecture;
 using GFramework.Core.Abstractions.enums;
+using GFramework.Core.Abstractions.lifecycle;
 using GFramework.Core.Abstractions.system;
 
 namespace GFramework.Core.Tests.system;

--- a/GFramework.Core.Tests/tests/ArchitectureTestsBase.cs
+++ b/GFramework.Core.Tests/tests/ArchitectureTestsBase.cs
@@ -34,11 +34,14 @@ public abstract class ArchitectureTestsBase<TArchitecture> where TArchitecture :
     ///     销毁架构实例并清理游戏上下文
     /// </summary>
     [TearDown]
-    public void TearDown()
+    public async Task TearDown()
     {
         try
         {
-            Architecture?.Destroy();
+            if (Architecture != null)
+            {
+                await Architecture.DestroyAsync();
+            }
         }
         finally
         {

--- a/GFramework.Core.Tests/tests/AsyncArchitectureTests.cs
+++ b/GFramework.Core.Tests/tests/AsyncArchitectureTests.cs
@@ -110,7 +110,7 @@ public class AsyncArchitectureTests : ArchitectureTestsBase<AsyncTestArchitectur
     public async Task Architecture_Destroy_Should_Destroy_All_Systems()
     {
         await Architecture!.InitializeAsync();
-        Architecture.Destroy();
+        await Architecture.DestroyAsync();
 
         var system = Architecture.Context.GetSystem<TestSystem>();
         Assert.That(system, Is.Null);

--- a/GFramework.Core.Tests/tests/SyncArchitectureTests.cs
+++ b/GFramework.Core.Tests/tests/SyncArchitectureTests.cs
@@ -114,10 +114,10 @@ public class SyncArchitectureTests : ArchitectureTestsBase<SyncTestArchitecture>
     ///     测试架构销毁功能，验证销毁后系统被正确销毁且架构进入销毁阶段
     /// </summary>
     [Test]
-    public void Architecture_Destroy_Should_Destroy_All_Systems_And_Enter_Destroyed()
+    public async Task Architecture_Destroy_Should_Destroy_All_Systems_And_Enter_Destroyed()
     {
         Architecture!.Initialize();
-        Architecture.Destroy();
+        await Architecture.DestroyAsync();
 
         var system = Architecture.Context.GetSystem<TestSystem>();
         Assert.That(system!.DestroyCalled, Is.True);

--- a/GFramework.Core/architecture/Architecture.cs
+++ b/GFramework.Core/architecture/Architecture.cs
@@ -11,7 +11,6 @@ using GFramework.Core.environment;
 using GFramework.Core.extensions;
 using GFramework.Core.logging;
 using Microsoft.Extensions.DependencyInjection;
-using IDisposable = GFramework.Core.Abstractions.lifecycle.IDisposable;
 
 namespace GFramework.Core.architecture;
 
@@ -117,12 +116,12 @@ public abstract class Architecture(
     /// <summary>
     ///     可销毁组件的去重集合
     /// </summary>
-    private readonly HashSet<IDisposable> _disposableSet = [];
+    private readonly HashSet<IDestroyable> _disposableSet = [];
 
     /// <summary>
     ///     存储所有需要销毁的组件（统一管理，保持注册逆序销毁）
     /// </summary>
-    private readonly List<IDisposable> _disposables = [];
+    private readonly List<IDestroyable> _disposables = [];
 
     /// <summary>
     ///     生命周期感知对象列表
@@ -262,7 +261,7 @@ public abstract class Architecture(
         }
 
         // 处理销毁
-        if (component is not IDisposable disposable) return;
+        if (component is not IDestroyable disposable) return;
         // 原子去重：HashSet.Add 返回 true 表示添加成功（之前不存在）
         if (_disposableSet.Add(disposable))
         {
@@ -377,7 +376,7 @@ public abstract class Architecture(
         _logger.Info("Starting architecture destruction");
         EnterPhase(ArchitecturePhase.Destroying);
 
-        // 销毁所有实现了 IDisposable 的组件（按注册逆序销毁）
+        // 销毁所有实现了 IDestroyable 的组件（按注册逆序销毁）
         _logger.Info($"Destroying {_disposables.Count} disposable components");
 
         for (var i = _disposables.Count - 1; i >= 0; i--)

--- a/GFramework.Core/architecture/ArchitectureContext.cs
+++ b/GFramework.Core/architecture/ArchitectureContext.cs
@@ -166,29 +166,6 @@ public class ArchitectureContext(IIocContainer container) : IArchitectureContext
         return await SendRequestAsync(command, cancellationToken);
     }
 
-    /// <summary>
-    /// [扩展] 发送查询
-    /// 语法糖，等同于 SendRequestAsync，语义更清晰
-    /// </summary>
-    public async ValueTask<TResponse> QueryAsync<TResponse>(
-        IRequest<TResponse> query,
-        CancellationToken cancellationToken = default)
-    {
-        return await SendRequestAsync(query, cancellationToken);
-    }
-
-    /// <summary>
-    /// [扩展] 发布事件通知
-    /// 语法糖，等同于 PublishAsync
-    /// </summary>
-    public async ValueTask PublishEventAsync<TNotification>(
-        TNotification notification,
-        CancellationToken cancellationToken = default)
-        where TNotification : INotification
-    {
-        await PublishAsync(notification, cancellationToken);
-    }
-
     #endregion
 
     #region Query Execution
@@ -211,11 +188,11 @@ public class ArchitectureContext(IIocContainer container) : IArchitectureContext
     /// [Mediator] 发送查询的同步版本（不推荐，仅用于兼容性）
     /// </summary>
     /// <typeparam name="TResponse">查询响应类型</typeparam>
-    /// <param name="command">要发送的查询对象</param>
+    /// <param name="query">要发送的查询对象</param>
     /// <returns>查询结果</returns>
-    public TResponse SendQuery<TResponse>(Mediator.IQuery<TResponse> command)
+    public TResponse SendQuery<TResponse>(Mediator.IQuery<TResponse> query)
     {
-        return SendQueryAsync(command).AsTask().GetAwaiter().GetResult();
+        return SendQueryAsync(query).AsTask().GetAwaiter().GetResult();
     }
 
     /// <summary>
@@ -237,19 +214,19 @@ public class ArchitectureContext(IIocContainer container) : IArchitectureContext
     /// 通过Mediator模式发送查询请求，支持取消操作
     /// </summary>
     /// <typeparam name="TResponse">查询响应类型</typeparam>
-    /// <param name="command">要发送的查询对象</param>
+    /// <param name="query">要发送的查询对象</param>
     /// <param name="cancellationToken">取消令牌，用于取消操作</param>
     /// <returns>包含查询结果的ValueTask</returns>
-    public async ValueTask<TResponse> SendQueryAsync<TResponse>(Mediator.IQuery<TResponse> command,
+    public async ValueTask<TResponse> SendQueryAsync<TResponse>(Mediator.IQuery<TResponse> query,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(query);
 
         var sender = Sender;
         if (sender == null)
             throw new InvalidOperationException("Sender not registered.");
 
-        return await sender.Send(command, cancellationToken);
+        return await sender.Send(query, cancellationToken);
     }
 
     #endregion

--- a/GFramework.Core/coroutine/instructions/WaitForEvent.cs
+++ b/GFramework.Core/coroutine/instructions/WaitForEvent.cs
@@ -15,9 +15,10 @@ using GFramework.Core.Abstractions.coroutine;
 using GFramework.Core.Abstractions.events;
 
 namespace GFramework.Core.coroutine.instructions;
+
 /// <summary>
 ///     WaitForEvent 类用于等待特定事件的发生，并提供事件数据和完成状态。
-///     实现了 IYieldInstruction 和 IDisposable 接口，支持协程等待和资源释放。
+///     实现了 IYieldInstruction 和 IDestroyable 接口，支持协程等待和资源释放。
 /// </summary>
 /// <typeparam name="TEvent">事件类型</typeparam>
 public sealed class WaitForEvent<TEvent> : IYieldInstruction, IDisposable

--- a/GFramework.Core/coroutine/instructions/WaitForMultipleEvents.cs
+++ b/GFramework.Core/coroutine/instructions/WaitForMultipleEvents.cs
@@ -5,7 +5,7 @@ namespace GFramework.Core.coroutine.instructions;
 
 /// <summary>
 ///     等待多个事件中的任意一个触发的指令
-///     实现了 IDisposable 接口，支持资源释放
+///     实现了 IDestroyable 接口，支持资源释放
 /// </summary>
 /// <typeparam name="TEvent1">第一个事件类型</typeparam>
 /// <typeparam name="TEvent2">第二个事件类型</typeparam>

--- a/GFramework.Core/extensions/ContextAwareExtensions.cs
+++ b/GFramework.Core/extensions/ContextAwareExtensions.cs
@@ -456,43 +456,4 @@ public static class ContextAwareExtensions
         var context = contextAware.GetContext();
         return context.SendAsync(command, cancellationToken);
     }
-
-    /// <summary>
-    ///     发送查询
-    /// </summary>
-    /// <typeparam name="TResponse">响应类型</typeparam>
-    /// <param name="contextAware">实现 IContextAware 接口的对象</param>
-    /// <param name="query">要发送的查询</param>
-    /// <param name="cancellationToken">取消令牌</param>
-    /// <returns>查询结果</returns>
-    /// <exception cref="ArgumentNullException">当 contextAware 或 query 为 null 时抛出</exception>
-    public static ValueTask<TResponse> QueryAsync<TResponse>(this IContextAware contextAware,
-        IRequest<TResponse> query, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(contextAware);
-        ArgumentNullException.ThrowIfNull(query);
-
-        var context = contextAware.GetContext();
-        return context.QueryAsync(query, cancellationToken);
-    }
-
-    /// <summary>
-    ///     发布事件通知
-    /// </summary>
-    /// <typeparam name="TNotification">通知类型</typeparam>
-    /// <param name="contextAware">实现 IContextAware 接口的对象</param>
-    /// <param name="notification">要发布的通知</param>
-    /// <param name="cancellationToken">取消令牌</param>
-    /// <returns>异步任务</returns>
-    /// <exception cref="ArgumentNullException">当 contextAware 或 notification 为 null 时抛出</exception>
-    public static ValueTask PublishEventAsync<TNotification>(this IContextAware contextAware,
-        TNotification notification, CancellationToken cancellationToken = default)
-        where TNotification : INotification
-    {
-        ArgumentNullException.ThrowIfNull(contextAware);
-        ArgumentNullException.ThrowIfNull(notification);
-
-        var context = contextAware.GetContext();
-        return context.PublishEventAsync(notification, cancellationToken);
-    }
 }

--- a/GFramework.Core/state/AsyncContextAwareStateBase.cs
+++ b/GFramework.Core/state/AsyncContextAwareStateBase.cs
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 using GFramework.Core.Abstractions.architecture;
+using GFramework.Core.Abstractions.lifecycle;
 using GFramework.Core.Abstractions.rule;
 using GFramework.Core.Abstractions.state;
-using IDisposable = GFramework.Core.Abstractions.lifecycle.IDisposable;
 
 namespace GFramework.Core.state;
 
@@ -23,7 +23,7 @@ namespace GFramework.Core.state;
 ///     提供基础的异步状态管理功能和架构上下文访问能力
 ///     实现了IAsyncState（继承IState）和IContextAware接口
 /// </summary>
-public class AsyncContextAwareStateBase : IAsyncState, IContextAware, IDisposable
+public class AsyncContextAwareStateBase : IAsyncState, IContextAware, IDestroyable
 {
     /// <summary>
     ///     架构上下文引用，用于访问架构相关的服务和数据

--- a/GFramework.Core/state/AsyncContextAwareStateBase.cs
+++ b/GFramework.Core/state/AsyncContextAwareStateBase.cs
@@ -21,14 +21,25 @@ namespace GFramework.Core.state;
 /// <summary>
 ///     上下文感知异步状态基类
 ///     提供基础的异步状态管理功能和架构上下文访问能力
-///     实现了IAsyncState（继承IState）和IContextAware接口
+///     实现了IAsyncState（继承IState）、IContextAware和IAsyncDestroyable接口
 /// </summary>
-public class AsyncContextAwareStateBase : IAsyncState, IContextAware, IDestroyable
+public class AsyncContextAwareStateBase : IAsyncState, IContextAware, IDestroyable, IAsyncDestroyable
 {
     /// <summary>
     ///     架构上下文引用，用于访问架构相关的服务和数据
     /// </summary>
     private IArchitectureContext? _context;
+
+    /// <summary>
+    ///     异步销毁当前状态，释放相关资源
+    ///     子类可重写此方法以执行特定的异步清理操作
+    /// </summary>
+    public virtual ValueTask DestroyAsync()
+    {
+        // 默认实现：调用同步 Destroy()
+        Destroy();
+        return ValueTask.CompletedTask;
+    }
 
     // ============ IState 同步方法显式实现（隐藏 + 运行时保护） ============
 
@@ -125,7 +136,7 @@ public class AsyncContextAwareStateBase : IAsyncState, IContextAware, IDestroyab
     }
 
     /// <summary>
-    ///     销毁当前状态，释放相关资源
+    ///     销毁当前状态，释放相关资源（同步方法，保留用于向后兼容）
     ///     子类可重写此方法以执行特定的清理操作
     /// </summary>
     public virtual void Destroy()

--- a/GFramework.Core/state/ContextAwareStateBase.cs
+++ b/GFramework.Core/state/ContextAwareStateBase.cs
@@ -1,7 +1,7 @@
 ﻿using GFramework.Core.Abstractions.architecture;
+using GFramework.Core.Abstractions.lifecycle;
 using GFramework.Core.Abstractions.rule;
 using GFramework.Core.Abstractions.state;
-using IDisposable = GFramework.Core.Abstractions.lifecycle.IDisposable;
 
 namespace GFramework.Core.state;
 
@@ -10,7 +10,7 @@ namespace GFramework.Core.state;
 ///     提供基础的状态管理功能和架构上下文访问能力
 ///     实现了IState和IContextAware接口
 /// </summary>
-public class ContextAwareStateBase : IState, IContextAware, IDisposable
+public class ContextAwareStateBase : IState, IContextAware, IDestroyable
 {
     /// <summary>
     ///     架构上下文引用，用于访问架构相关的服务和数据

--- a/GFramework.Core/state/StateMachineSystem.cs
+++ b/GFramework.Core/state/StateMachineSystem.cs
@@ -1,9 +1,9 @@
 using GFramework.Core.Abstractions.architecture;
 using GFramework.Core.Abstractions.enums;
+using GFramework.Core.Abstractions.lifecycle;
 using GFramework.Core.Abstractions.rule;
 using GFramework.Core.Abstractions.state;
 using GFramework.Core.extensions;
-using IDisposable = GFramework.Core.Abstractions.lifecycle.IDisposable;
 
 namespace GFramework.Core.state;
 
@@ -74,7 +74,7 @@ public class StateMachineSystem : StateMachine, IStateMachineSystem
         }
 
         // 清理所有状态
-        foreach (var state in States.Values.OfType<IDisposable>()) state.Destroy();
+        foreach (var state in States.Values.OfType<IDestroyable>()) state.Destroy();
 
         States.Clear();
     }

--- a/GFramework.Core/state/StateMachineSystem.cs
+++ b/GFramework.Core/state/StateMachineSystem.cs
@@ -61,7 +61,15 @@ public class StateMachineSystem : StateMachine, IStateMachineSystem
         // 退出当前状态
         if (Current != null)
         {
-            Current.OnExit(null);
+            if (Current is IAsyncState asyncState)
+            {
+                asyncState.OnExitAsync(null);
+            }
+            else
+            {
+                Current.OnExit(null);
+            }
+
             Current = null;
         }
 

--- a/GFramework.Godot/coroutine/ContextAwareCoroutineExtensions.cs
+++ b/GFramework.Godot/coroutine/ContextAwareCoroutineExtensions.cs
@@ -99,7 +99,7 @@ public static class ContextAwareCoroutineExtensions
         CancellationToken cancellationToken = default)
     {
         return contextAware
-            .PublishEventAsync(notification, cancellationToken)
+            .PublishAsync(notification, cancellationToken)
             .AsTask()
             .ToCoroutineEnumerator()
             .RunCoroutine(segment, tag);


### PR DESCRIPTION
## Summary by Sourcery

Remove query/event convenience methods from the architecture context APIs and align callers with the core mediator-style query and publish methods.

Enhancements:
- Simplify ArchitectureContext and IArchitectureContext by removing redundant QueryAsync and PublishEventAsync sugar methods and standardizing parameter naming for query operations.
- Update coroutine and other framework integrations to use the core PublishAsync/SendQueryAsync APIs instead of the removed sugar methods.
- Adjust test contexts and fakes to match the updated architecture context interface and remove tests that targeted the deleted convenience APIs.
- Improve state machine destruction to support async states by invoking OnExitAsync when available.