### PR TITLE
chore(deps): 更新项目依赖包版本

### DIFF
--- a/GFramework.Core.Abstractions/GFramework.Core.Abstractions.csproj
+++ b/GFramework.Core.Abstractions/GFramework.Core.Abstractions.csproj
@@ -17,7 +17,7 @@
         <Using Include="GFramework.Core.Abstractions"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="Meziantou.Analyzer" Version="2.0.302">
+        <PackageReference Update="Meziantou.Analyzer" Version="3.0.9">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/GFramework.Game.Abstractions/GFramework.Game.Abstractions.csproj
+++ b/GFramework.Game.Abstractions/GFramework.Game.Abstractions.csproj
@@ -19,7 +19,7 @@
         <Using Include="GFramework.Game.Abstractions"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="Meziantou.Analyzer" Version="2.0.302">
+        <PackageReference Update="Meziantou.Analyzer" Version="3.0.9">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/GFramework.Godot.SourceGenerators.Abstractions/GFramework.Godot.SourceGenerators.Abstractions.csproj
+++ b/GFramework.Godot.SourceGenerators.Abstractions/GFramework.Godot.SourceGenerators.Abstractions.csproj
@@ -19,7 +19,7 @@
         <Folder Include="logging\"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="Meziantou.Analyzer" Version="2.0.302">
+        <PackageReference Update="Meziantou.Analyzer" Version="3.0.9">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/GFramework.Godot/GFramework.Godot.csproj
+++ b/GFramework.Godot/GFramework.Godot.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Godot.SourceGenerators" Version="4.6.0" PrivateAssets="all"/>
+        <PackageReference Include="Godot.SourceGenerators" Version="4.6.1" PrivateAssets="all"/>
         <PackageReference Include="GodotSharp" Version="4.6.1"/>
         <PackageReference Include="GodotSharpEditor" Version="4.6.1" PrivateAssets="all"/>
         <PackageReference Include="LanguageExt.Core" Version="4.4.9"/>

--- a/GFramework.SourceGenerators.Abstractions/GFramework.SourceGenerators.Abstractions.csproj
+++ b/GFramework.SourceGenerators.Abstractions/GFramework.SourceGenerators.Abstractions.csproj
@@ -18,7 +18,7 @@
         <ProjectReference Include="..\GFramework.Core.Abstractions\GFramework.Core.Abstractions.csproj" PrivateAssets="all"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="Meziantou.Analyzer" Version="2.0.302">
+        <PackageReference Update="Meziantou.Analyzer" Version="3.0.9">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/GFramework.SourceGenerators.Common/GFramework.SourceGenerators.Common.csproj
+++ b/GFramework.SourceGenerators.Common/GFramework.SourceGenerators.Common.csproj
@@ -22,7 +22,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all"/>
-        <PackageReference Update="Meziantou.Analyzer" Version="2.0.302">
+        <PackageReference Update="Meziantou.Analyzer" Version="3.0.9">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
- 将 Meziantou.Analyzer 从 2.0.302 版本更新到 3.0.9 版本
- 将 Godot.SourceGenerators 从 4.6.0 版本更新到 4.6.1 版本
- 在多个项目文件中统一更新了代码分析器依赖版本

## Summary by Sourcery

Update code analyzer and source generator dependency versions across the solution.

Build:
- Bump Meziantou.Analyzer package version from 2.0.302 to 3.0.9 in relevant project files.
- Bump Godot.SourceGenerators package version from 4.6.0 to 4.6.1 and align analyzer versions across multiple projects.