### PR TITLE
feat(scene): 添加环绕场景过渡处理器注册功能

### DIFF
--- a/GFramework.Game/scene/SceneRouterBase.cs
+++ b/GFramework.Game/scene/SceneRouterBase.cs
@@ -142,6 +142,28 @@ public abstract class SceneRouterBase
     }
 
     /// <summary>
+    /// 注册环绕场景过渡处理器。
+    /// </summary>
+    /// <param name="handler">环绕处理器实例。</param>
+    /// <param name="options">处理器选项配置。</param>
+    public void RegisterAroundHandler(
+        ISceneAroundTransitionHandler handler,
+        SceneTransitionHandlerOptions? options = null)
+    {
+        _pipeline.RegisterAroundHandler(handler, options);
+    }
+
+    /// <summary>
+    /// 注销环绕场景过渡处理器。
+    /// </summary>
+    /// <param name="handler">环绕处理器实例。</param>
+    public void UnregisterAroundHandler(
+        ISceneAroundTransitionHandler handler)
+    {
+        _pipeline.UnregisterAroundHandler(handler);
+    }
+
+    /// <summary>
     /// 添加场景路由守卫。
     /// </summary>
     /// <param name="guard">守卫实例。</param>


### PR DESCRIPTION
- 实现 RegisterAroundHandler 方法用于注册环绕场景过渡处理器
- 实现 UnregisterAroundHandler 方法用于注销环绕场景过渡处理器
- 添加处理器选项配置参数支持
- 提供完整的环绕处理器生命周期管理功能

## Summary by Sourcery

Add support in the scene router for registering and unregistering around-scene transition handlers with optional configuration.

New Features:
- Introduce RegisterAroundHandler on SceneRouterBase to register around-scene transition handlers with optional handler options.
- Introduce UnregisterAroundHandler on SceneRouterBase to unregister previously registered around-scene transition handlers.