### PR TITLE
feat(registries): 扩展注册表接口功能并实现基础类

### DIFF
--- a/GFramework.Core.Abstractions/registries/IRegistry.cs
+++ b/GFramework.Core.Abstractions/registries/IRegistry.cs
@@ -7,8 +7,18 @@ namespace GFramework.Core.Abstractions.registries;
 /// </summary>
 /// <typeparam name="T">注册表中用作键的类型</typeparam>
 /// <typeparam name="Tr">注册表中存储的值的类型</typeparam>
-public interface IRegistry<in T, Tr>
+public interface IRegistry<T, Tr>
 {
+    /// <summary>
+    ///     获取注册表中所有的键
+    /// </summary>
+    IEnumerable<T> Keys { get; }
+
+    /// <summary>
+    ///     获取注册表中项的数量
+    /// </summary>
+    int Count { get; }
+
     /// <summary>
     ///     根据指定的键获取对应的值
     /// </summary>
@@ -35,4 +45,24 @@ public interface IRegistry<in T, Tr>
     /// <param name="key">要添加的键</param>
     /// <param name="value">要添加的值</param>
     IRegistry<T, Tr> Registry(T key, Tr value);
+
+    /// <summary>
+    ///     从注册表中移除指定键的项
+    /// </summary>
+    /// <param name="key">要移除的键</param>
+    /// <returns>如果成功移除则返回true，否则返回false</returns>
+    bool Unregister(T key);
+
+    /// <summary>
+    ///     获取注册表中所有的键值对
+    /// </summary>
+    /// <returns>包含所有注册键值对的只读字典</returns>
+    IReadOnlyDictionary<T, Tr> GetAll();
+
+
+    /// <summary>
+    ///     获取注册表中所有的值
+    /// </summary>
+    /// <returns>包含所有注册值的只读集合</returns>
+    IReadOnlyCollection<Tr> Values();
 }

--- a/GFramework.Core.Abstractions/registries/KeyValueRegistryBase.cs
+++ b/GFramework.Core.Abstractions/registries/KeyValueRegistryBase.cs
@@ -98,7 +98,7 @@ public abstract class KeyValueRegistryBase<TKey, TValue>
     /// <returns>包含所有注册值的只读集合</returns>
     public IReadOnlyCollection<TValue> Values()
     {
-        return Map.Values as IReadOnlyCollection<TValue> ?? new ReadOnlyCollection<TValue>([]);
+        return Map.Values as IReadOnlyCollection<TValue> ?? new ReadOnlyCollection<TValue>(Map.Values.ToList());
     }
 
     /// <summary>

--- a/GFramework.Core.Abstractions/registries/KeyValueRegistryBase.cs
+++ b/GFramework.Core.Abstractions/registries/KeyValueRegistryBase.cs
@@ -1,4 +1,5 @@
-﻿using GFramework.Core.Abstractions.bases;
+﻿using System.Collections.ObjectModel;
+using GFramework.Core.Abstractions.bases;
 
 namespace GFramework.Core.Abstractions.registries;
 
@@ -61,6 +62,7 @@ public abstract class KeyValueRegistryBase<TKey, TValue>
         return this;
     }
 
+
     /// <summary>
     ///     注册键值对映射对象到注册表中
     /// </summary>
@@ -70,4 +72,42 @@ public abstract class KeyValueRegistryBase<TKey, TValue>
     {
         return Registry(mapping.Key, mapping.Value);
     }
+
+    /// <summary>
+    ///     从注册表中移除指定键的项
+    /// </summary>
+    /// <param name="key">要移除的键</param>
+    /// <returns>如果成功移除则返回true，否则返回false</returns>
+    public bool Unregister(TKey key)
+    {
+        return Map.Remove(key);
+    }
+
+    /// <summary>
+    ///     获取注册表中所有的键值对
+    /// </summary>
+    /// <returns>包含所有注册键值对的只读字典</returns>
+    public IReadOnlyDictionary<TKey, TValue> GetAll()
+    {
+        return Map as IReadOnlyDictionary<TKey, TValue> ?? new ReadOnlyDictionary<TKey, TValue>(Map);
+    }
+
+    /// <summary>
+    ///     获取注册表中所有的值
+    /// </summary>
+    /// <returns>包含所有注册值的只读集合</returns>
+    public IReadOnlyCollection<TValue> Values()
+    {
+        return Map.Values as IReadOnlyCollection<TValue> ?? new ReadOnlyCollection<TValue>([]);
+    }
+
+    /// <summary>
+    ///     获取注册表中所有的键
+    /// </summary>
+    public IEnumerable<TKey> Keys => Map.Keys;
+
+    /// <summary>
+    ///     获取注册表中项的数量
+    /// </summary>
+    public int Count => Map.Count;
 }


### PR DESCRIPTION
- 移除 IRegistry 接口中的 in 泛型约束
- 添加 Unregister 方法用于移除指定键的项
- 添加 GetAll 方法用于获取所有键值对
- 添加 Values 方法用于获取所有注册值
- 添加 Keys 属性用于获取所有键
- 添加 Count 属性用于获取项的数量
- 在 KeyValueRegistryBase 中实现新增的接口方法
- 添加 System.Collections.ObjectModel 引用支持只读集合

## Summary by Sourcery

Extend the registry abstraction with richer query and management capabilities and implement them in the base key-value registry.

New Features:
- Add key enumeration and item count properties to the registry interface.
- Add methods to unregister entries, retrieve all key-value pairs, and get all values as read-only collections on the registry interface and base implementation.

Enhancements:
- Update the key-value registry base class to support the expanded registry interface using read-only dictionary and collection types.