### PR TITLE
chore(dependencies): 移除 LanguageExt 相关依赖和引用

### DIFF
--- a/GFramework.Game/GFramework.Game.csproj
+++ b/GFramework.Game/GFramework.Game.csproj
@@ -12,7 +12,6 @@
         <ProjectReference Include="..\$(AssemblyName).Abstractions\$(AssemblyName).Abstractions.csproj"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="LanguageExt.Core" Version="4.4.9"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4"/>
     </ItemGroup>
 </Project>

--- a/GFramework.Game/GlobalUsings.cs
+++ b/GFramework.Game/GlobalUsings.cs
@@ -17,6 +17,3 @@ global using System.Collections.Concurrent;
 global using System.Linq;
 global using System.Threading;
 global using System.Threading.Tasks;
-global using LanguageExt.Common;
-global using LanguageExt.Effects;
-global using LanguageExt.Pretty;

--- a/GFramework.Godot/GFramework.Godot.csproj
+++ b/GFramework.Godot/GFramework.Godot.csproj
@@ -12,7 +12,6 @@
         <PackageReference Include="Godot.SourceGenerators" Version="4.6.1" PrivateAssets="all"/>
         <PackageReference Include="GodotSharp" Version="4.6.1"/>
         <PackageReference Include="GodotSharpEditor" Version="4.6.1" PrivateAssets="all"/>
-        <PackageReference Include="LanguageExt.Core" Version="4.4.9"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/GFramework.Godot/GlobalUsings.cs
+++ b/GFramework.Godot/GlobalUsings.cs
@@ -16,6 +16,3 @@ global using System.Collections.Generic;
 global using System.Linq;
 global using System.Threading;
 global using System.Threading.Tasks;
-global using LanguageExt.Common;
-global using LanguageExt.Effects;
-global using LanguageExt.Pretty;


### PR DESCRIPTION
- 从 GFramework.Game 项目中移除 LanguageExt.Core 包引用
- 从 GFramework.Godot 项目中移除 LanguageExt.Core 包引用
- 从全局引用文件中移除 LanguageExt.Common 引用
- 从全局引用文件中移除 LanguageExt.Effects 引用
- 从全局引用文件中移除 LanguageExt.Pretty 引用
- 保留必要的 System.Threading.Tasks 引用

## Summary by Sourcery

从 game 和 Godot 项目中移除 LanguageExt 依赖以及相关的全局 using。

Enhancements:
- 通过移除 GFramework.Game 和 GFramework.Godot 中未使用的 LanguageExt 命名空间来清理全局 using 指令。

Chores:
- 从 GFramework.Game 和 GFramework.Godot 项目中移除对 LanguageExt 包的依赖和引用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove LanguageExt dependencies and related global usings from the game and Godot projects.

Enhancements:
- Clean up global using directives by dropping unused LanguageExt namespaces from GFramework.Game and GFramework.Godot.

Chores:
- Remove LanguageExt package dependencies and references from the GFramework.Game and GFramework.Godot projects.

</details>