### PR TITLE
refactor(godot): 将异步方法重命名为遵循Async约定的方法名

### DIFF
--- a/GFramework.Core.Tests/extensions/AsyncExtensionsTests.cs
+++ b/GFramework.Core.Tests/extensions/AsyncExtensionsTests.cs
@@ -18,7 +18,7 @@ public class AsyncExtensionsTests
     public async Task WithTimeout_Should_Return_Result_When_Task_Completes_Before_Timeout()
     {
         // Act
-        var result = await AsyncExtensions.WithTimeout(
+        var result = await AsyncExtensions.WithTimeoutAsync(
             _ => Task.FromResult(42),
             TimeSpan.FromSeconds(1));
 
@@ -34,7 +34,7 @@ public class AsyncExtensionsTests
     {
         // Act & Assert
         Assert.ThrowsAsync<TimeoutException>(async () =>
-            await AsyncExtensions.WithTimeout(
+            await AsyncExtensions.WithTimeoutAsync(
                 async ct =>
                 {
                     await Task.Delay(TimeSpan.FromSeconds(2), ct);
@@ -54,7 +54,7 @@ public class AsyncExtensionsTests
         cts.Cancel();
         // Act & Assert
         Assert.ThrowsAsync<TaskCanceledException>(async () =>
-            await AsyncExtensions.WithTimeout(
+            await AsyncExtensions.WithTimeoutAsync(
                 async ct =>
                 {
                     await Task.Delay(TimeSpan.FromSeconds(2), ct);
@@ -75,7 +75,7 @@ public class AsyncExtensionsTests
 
         // Act & Assert
         Assert.ThrowsAsync<TimeoutException>(async () =>
-            await AsyncExtensions.WithTimeout(
+            await AsyncExtensions.WithTimeoutAsync(
                 async ct =>
                 {
                     try
@@ -104,7 +104,7 @@ public class AsyncExtensionsTests
         var stopwatch = Stopwatch.StartNew();
 
         // Act
-        await AsyncExtensions.WithTimeout(
+        await AsyncExtensions.WithTimeoutAsync(
             _ => Task.CompletedTask,
             TimeSpan.FromSeconds(1));
         stopwatch.Stop();
@@ -122,7 +122,7 @@ public class AsyncExtensionsTests
     {
         // Act & Assert
         Assert.ThrowsAsync<TimeoutException>(async () =>
-            await AsyncExtensions.WithTimeout(
+            await AsyncExtensions.WithTimeoutAsync(
                 ct => Task.Delay(TimeSpan.FromSeconds(2), ct),
                 TimeSpan.FromMilliseconds(100)));
     }
@@ -138,7 +138,7 @@ public class AsyncExtensionsTests
 
         // Act & Assert
         Assert.ThrowsAsync<TimeoutException>(async () =>
-            await AsyncExtensions.WithTimeout(
+            await AsyncExtensions.WithTimeoutAsync(
                 async ct =>
                 {
                     try
@@ -171,7 +171,7 @@ public class AsyncExtensionsTests
         };
 
         // Act
-        var result = await taskFactory.WithRetry(3, TimeSpan.FromMilliseconds(10));
+        var result = await taskFactory.WithRetryAsync(3, TimeSpan.FromMilliseconds(10));
 
         // Assert
         Assert.That(result, Is.EqualTo(42));
@@ -195,7 +195,7 @@ public class AsyncExtensionsTests
         };
 
         // Act
-        var result = await taskFactory.WithRetry(3, TimeSpan.FromMilliseconds(10));
+        var result = await taskFactory.WithRetryAsync(3, TimeSpan.FromMilliseconds(10));
 
         // Assert
         Assert.That(result, Is.EqualTo(42));
@@ -218,7 +218,7 @@ public class AsyncExtensionsTests
 
         // Act & Assert
         Assert.ThrowsAsync<AggregateException>(async () =>
-            await taskFactory.WithRetry(2, TimeSpan.FromMilliseconds(10)));
+            await taskFactory.WithRetryAsync(2, TimeSpan.FromMilliseconds(10)));
     }
 
     /// <summary>
@@ -237,7 +237,7 @@ public class AsyncExtensionsTests
 
         // Act & Assert
         Assert.ThrowsAsync<AggregateException>(async () =>
-            await taskFactory.WithRetry(3, TimeSpan.FromMilliseconds(10),
+            await taskFactory.WithRetryAsync(3, TimeSpan.FromMilliseconds(10),
                 ex => ex is not ArgumentException));
 
         await Task.Delay(50); // 等待任务完成
@@ -287,7 +287,7 @@ public class AsyncExtensionsTests
         var task = Task.FromResult(42);
 
         // Act
-        var result = await task.WithFallback(_ => -1);
+        var result = await task.WithFallbackAsync(_ => -1);
 
         // Assert
         Assert.That(result, Is.EqualTo(42));
@@ -303,7 +303,7 @@ public class AsyncExtensionsTests
         var task = Task.FromException<int>(new InvalidOperationException("Test error"));
 
         // Act
-        var result = await task.WithFallback(_ => -1);
+        var result = await task.WithFallbackAsync(_ => -1);
 
         // Assert
         Assert.That(result, Is.EqualTo(-1));
@@ -321,7 +321,7 @@ public class AsyncExtensionsTests
         Exception? capturedEx = null;
 
         // Act
-        await task.WithFallback(ex =>
+        await task.WithFallbackAsync(ex =>
         {
             capturedEx = ex;
             return -1;

--- a/GFramework.Core/extensions/AsyncExtensions.cs
+++ b/GFramework.Core/extensions/AsyncExtensions.cs
@@ -18,12 +18,12 @@ public static class AsyncExtensions
     /// <exception cref="OperationCanceledException">当操作被取消时抛出</exception>
     /// <example>
     /// <code>
-    /// var result = await WithTimeout(
+    /// var result = await WithTimeoutAsync(
     ///     ct => SomeAsyncOperation(ct),
     ///     TimeSpan.FromSeconds(5));
     /// </code>
     /// </example>
-    public static async Task<T> WithTimeout<T>(
+    public static async Task<T> WithTimeoutAsync<T>(
         Func<CancellationToken, Task<T>> taskFactory,
         TimeSpan timeout,
         CancellationToken cancellationToken = default)
@@ -66,7 +66,7 @@ public static class AsyncExtensions
     /// <exception cref="ArgumentNullException">当 taskFactory 为 null 时抛出</exception>
     /// <exception cref="TimeoutException">当任务超时时抛出</exception>
     /// <exception cref="OperationCanceledException">当操作被取消时抛出</exception>
-    public static async Task WithTimeout(
+    public static async Task WithTimeoutAsync(
         Func<CancellationToken, Task> taskFactory,
         TimeSpan timeout,
         CancellationToken cancellationToken = default)
@@ -108,10 +108,10 @@ public static class AsyncExtensions
     /// <example>
     /// <code>
     /// var result = await RiskyOperation()
-    ///     .WithFallback(ex => DefaultValue);
+    ///     .WithFallbackAsync(ex => DefaultValue);
     /// </code>
     /// </example>
-    public static async Task<T> WithFallback<T>(this Task<T> task, Func<Exception, T> fallback)
+    public static async Task<T> WithFallbackAsync<T>(this Task<T> task, Func<Exception, T> fallback)
     {
         ArgumentNullException.ThrowIfNull(task);
         ArgumentNullException.ThrowIfNull(fallback);

--- a/GFramework.Core/functional/async/AsyncFunctionalExtensions.cs
+++ b/GFramework.Core/functional/async/AsyncFunctionalExtensions.cs
@@ -33,10 +33,10 @@ public static class AsyncFunctionalExtensions
     /// <example>
     /// <code>
     /// var result = await (() => UnreliableOperation())
-    ///     .WithRetry(maxRetries: 3, delay: TimeSpan.FromSeconds(1));
+    ///     .WithRetryAsync(maxRetries: 3, delay: TimeSpan.FromSeconds(1));
     /// </code>
     /// </example>
-    public static async Task<T> WithRetry<T>(
+    public static async Task<T> WithRetryAsync<T>(
         this Func<Task<T>> taskFactory,
         int maxRetries,
         TimeSpan delay,

--- a/GFramework.Godot/architecture/AbstractArchitecture.cs
+++ b/GFramework.Godot/architecture/AbstractArchitecture.cs
@@ -106,7 +106,7 @@ public abstract class AbstractArchitecture(
             throw new InvalidOperationException("Anchor not initialized");
 
         // 等待锚点准备就绪
-        await _anchor.WaitUntilReady();
+        await _anchor.WaitUntilReadyAsync();
 
         // 延迟调用将扩展节点添加为锚点的子节点
         _anchor.CallDeferred(Node.MethodName.AddChild, module.Node);

--- a/GFramework.Godot/extensions/NodeExtensions.cs
+++ b/GFramework.Godot/extensions/NodeExtensions.cs
@@ -51,7 +51,7 @@ public static class NodeExtensions
     /// </summary>
     /// <param name="node">要等待其准备就绪的节点</param>
     /// <returns>表示异步操作的任务</returns>
-    public static async Task WaitUntilReady(this Node node)
+    public static async Task WaitUntilReadyAsync(this Node node)
     {
         if (!node.IsInsideTree()) await node.ToSignal(node, Node.SignalName.Ready);
     }
@@ -173,10 +173,10 @@ public static class NodeExtensions
     /// <param name="parent">父节点</param>
     /// <param name="child">要添加的子节点</param>
     /// <returns>异步任务</returns>
-    public static async Task AddChildX(this Node parent, Node child)
+    public static async Task AddChildXAsync(this Node parent, Node child)
     {
         parent.AddChild(child);
-        await child.WaitUntilReady();
+        await child.WaitUntilReadyAsync();
     }
 
     /// <summary>

--- a/docs/zh-CN/godot/extensions.md
+++ b/docs/zh-CN/godot/extensions.md
@@ -62,7 +62,7 @@ node.QueueFreeX();  // 延迟释放
 node.FreeX();       // 立即释放
 
 // 等待节点就绪
-await node.WaitUntilReady();
+await node.WaitUntilReadyAsync();
 
 // 检查节点有效性
 if (node.IsValidNode()) Console.WriteLine("节点有效");
@@ -92,7 +92,7 @@ node.ForEachChild<Sprite2D>(sprite => {
 var root = node.GetRootNodeX();
 
 // 异步添加子节点
-await parent.AddChildX(childNode);
+await parent.AddChildXAsync(childNode);
 
 // 设置场景树暂停状态
 node.Paused(true);   // 暂停
@@ -178,7 +178,7 @@ public class GameManager : Node
         
         // 安全添加子节点
         var player = new Player();
-        await AddChildX(player);
+        await AddChildXAsync(player);
         
         // 查找并配置玩家
         var sprite = player.FindChildX<Sprite2D>("Sprite");
@@ -237,7 +237,7 @@ public class SceneManager : Node
         var instance = packedScene.Instantiate<T>();
         
         // 等待场景加载完成
-        await instance.WaitUntilReady();
+        await instance.WaitUntilReadyAsync();
         
         return instance;
     }
@@ -250,7 +250,7 @@ public class SceneManager : Node
         ForEachChild<Node>(child => child.QueueFreeX());
         
         // 加载新场景
-        await AddChildX(newScene);
+        await AddChildXAsync(newScene);
         
         // 设置输入处理
         newScene.SetInputAsHandled();
@@ -310,7 +310,7 @@ var button = node.FindChild("Button") as Button;
 
 ```csharp
 // ✅ 推荐：等待节点就绪
-await child.WaitUntilReady();
+await child.WaitUntilReadyAsync();
 
 // ❌ 避免：假设节点已就绪
 child.DoSomething();

--- a/docs/zh-CN/godot/index.md
+++ b/docs/zh-CN/godot/index.md
@@ -234,7 +234,7 @@ var bullet = bulletScene.Instantiate<Bullet>();
 AddChildX(bullet);
 
 // 等待节点准备就绪
-await bullet.WaitUntilReady();
+await bullet.WaitUntilReadyAsync();
 
 // 获取父节点
 var parent = GetParentX<GameLevel>();

--- a/docs/zh-CN/tutorials/godot-integration.md
+++ b/docs/zh-CN/tutorials/godot-integration.md
@@ -306,7 +306,7 @@ public partial class SafeNodeOperations : Node
         AddChildX(bullet);
         
         // 安全的异步操作
-        this.WaitUntilReady()
+        this.WaitUntilReadyAsync()
             .Then(() => {
                 // 节点准备就绪后的操作
                 InitializeAfterReady();


### PR DESCRIPTION
- 将WaitUntilReady方法重命名为WaitUntilReadyAsync
- 将AddChildX方法重命名为AddChildXAsync
- 更新所有相关文档中的方法调用引用
- 修改架构层锚点等待方法调用为异步版本
- 更新测试代码中的方法调用以匹配新的方法名
- 调整函数式异步扩展方法命名约定
- 统一所有异步扩展方法的命名规范

## 由 Sourcery 提供的总结

标准化异步扩展方法的命名，统一使用 `Async` 后缀，并在核心代码、Godot 集成以及文档中更新所有用法。

增强内容：
- 将核心异步工具方法（`WithTimeout`、`WithRetry`、`WithFallback`、`WaitUntilReady`、`AddChildX`）重命名为带有 `Async` 后缀的变体，以保持一致的命名规范。
- 调整 Godot 架构锚点安装逻辑，使用 `await` 调用新的带有 `Async` 后缀的就绪方法。

文档：
- 更新中文 Godot 扩展和集成文档，使其引用新的带有 `Async` 后缀的方法名和示例。

测试：
- 更新异步扩展测试以使用带有 `Async` 后缀的方法名，从而与新的命名约定保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize async extension method naming to use the Async suffix and update usages across core, Godot integration, and docs.

Enhancements:
- Rename core async utility methods (WithTimeout, WithRetry, WithFallback, WaitUntilReady, AddChildX) to Async-suffixed variants for consistent naming conventions.
- Adjust Godot architecture anchor installation to await the new Async-suffixed readiness method.

Documentation:
- Update Chinese Godot extension and integration docs to reference the new Async-suffixed method names and examples.

Tests:
- Update async extension tests to use Async-suffixed method names to align with the new naming convention.

</details>