### PR TITLE
refactor(GFramework.Core): 移除 ResultState 枚举的字节类型声明

### DIFF
--- a/GFramework.Core/functional/Result.T.cs
+++ b/GFramework.Core/functional/Result.T.cs
@@ -28,7 +28,7 @@ public readonly struct Result<A> : IEquatable<Result<A>>, IComparable<Result<A>>
     /// <summary>
     ///     表示 Result 结构体的内部状态
     /// </summary>
-    private enum ResultState : byte
+    private enum ResultState
     {
         /// <summary>
         ///     未初始化状态，表示 Result 尚未被赋值


### PR DESCRIPTION
- 移除了 ResultState 枚举的 byte 类型声明，改用默认整型
- 简化了枚举类型的定义，提高代码可读性

## Summary by Sourcery

增强内容：
- 简化 `ResultState` 枚举的定义，通过依赖默认的基础整数类型，而不是显式指定为 `byte`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Simplify the ResultState enum definition by relying on the default underlying integral type instead of explicitly specifying byte.

</details>