### PR TITLE
refactor(core): 移除废弃的同步命令查询扩展方法并简化类型引用

### DIFF
--- a/GFramework.Core/extensions/ContextAwareCommandExtensions.cs
+++ b/GFramework.Core/extensions/ContextAwareCommandExtensions.cs
@@ -9,24 +9,6 @@ namespace GFramework.Core.extensions;
 public static class ContextAwareCommandExtensions
 {
     /// <summary>
-    ///     [Mediator] 发送命令的同步版本（不推荐,仅用于兼容性）
-    /// </summary>
-    /// <typeparam name="TResponse">命令响应类型</typeparam>
-    /// <param name="contextAware">实现 IContextAware 接口的对象</param>
-    /// <param name="command">要发送的命令对象</param>
-    /// <returns>命令执行结果</returns>
-    /// <exception cref="ArgumentNullException">当 contextAware 或 command 为 null 时抛出</exception>
-    public static TResponse SendCommand<TResponse>(this IContextAware contextAware,
-        Mediator.ICommand<TResponse> command)
-    {
-        ArgumentNullException.ThrowIfNull(contextAware);
-        ArgumentNullException.ThrowIfNull(command);
-
-        var context = contextAware.GetContext();
-        return context.SendCommand(command);
-    }
-
-    /// <summary>
     ///     发送一个带返回结果的命令
     /// </summary>
     /// <typeparam name="TResult">命令执行结果类型</typeparam>
@@ -35,7 +17,7 @@ public static class ContextAwareCommandExtensions
     /// <returns>命令执行结果</returns>
     /// <exception cref="ArgumentNullException">当 contextAware 或 command 为 null 时抛出</exception>
     public static TResult SendCommand<TResult>(this IContextAware contextAware,
-        Abstractions.command.ICommand<TResult> command)
+        ICommand<TResult> command)
     {
         ArgumentNullException.ThrowIfNull(contextAware);
         ArgumentNullException.ThrowIfNull(command);
@@ -50,7 +32,7 @@ public static class ContextAwareCommandExtensions
     /// <param name="contextAware">实现 IContextAware 接口的对象</param>
     /// <param name="command">要发送的命令</param>
     /// <exception cref="ArgumentNullException">当 contextAware 或 command 为 null 时抛出</exception>
-    public static void SendCommand(this IContextAware contextAware, Abstractions.command.ICommand command)
+    public static void SendCommand(this IContextAware contextAware, ICommand command)
     {
         ArgumentNullException.ThrowIfNull(contextAware);
         ArgumentNullException.ThrowIfNull(command);

--- a/GFramework.Core/extensions/ContextAwareQueryExtensions.cs
+++ b/GFramework.Core/extensions/ContextAwareQueryExtensions.cs
@@ -9,23 +9,6 @@ namespace GFramework.Core.extensions;
 public static class ContextAwareQueryExtensions
 {
     /// <summary>
-    ///     [Mediator] 发送查询的同步版本（不推荐,仅用于兼容性）
-    /// </summary>
-    /// <typeparam name="TResponse">查询响应类型</typeparam>
-    /// <param name="contextAware">实现 IContextAware 接口的对象</param>
-    /// <param name="query">要发送的查询对象</param>
-    /// <returns>查询结果</returns>
-    /// <exception cref="ArgumentNullException">当 contextAware 或 query 为 null 时抛出</exception>
-    public static TResponse SendQuery<TResponse>(this IContextAware contextAware, Mediator.IQuery<TResponse> query)
-    {
-        ArgumentNullException.ThrowIfNull(contextAware);
-        ArgumentNullException.ThrowIfNull(query);
-
-        var context = contextAware.GetContext();
-        return context.SendQuery(query);
-    }
-
-    /// <summary>
     ///     发送一个查询请求
     /// </summary>
     /// <typeparam name="TResult">查询结果类型</typeparam>
@@ -33,7 +16,7 @@ public static class ContextAwareQueryExtensions
     /// <param name="query">要发送的查询</param>
     /// <returns>查询结果</returns>
     /// <exception cref="ArgumentNullException">当 contextAware 或 query 为 null 时抛出</exception>
-    public static TResult SendQuery<TResult>(this IContextAware contextAware, Abstractions.query.IQuery<TResult> query)
+    public static TResult SendQuery<TResult>(this IContextAware contextAware, IQuery<TResult> query)
     {
         ArgumentNullException.ThrowIfNull(contextAware);
         ArgumentNullException.ThrowIfNull(query);


### PR DESCRIPTION
- 移除了 ContextAwareCommandExtensions 中废弃的 SendCommand 同步方法
- 移除了 ContextAwareQueryExtensions 中废弃的 SendQuery 同步方法
- 简化了 ICommand 和 IQuery 的类型引用，移除冗长的命名空间前缀
- 保持了异步命令和查询方法的功能完整性

## Summary by Sourcery

移除已弃用的、支持上下文的 Mediator 同步命令/查询辅助方法，并简化命令/查询类型的使用。

增强内容：
- 从支持上下文的扩展中移除基于 Mediator 的传统同步扩展方法 `SendCommand` 和 `SendQuery`。
- 在支持上下文的扩展中，通过直接使用接口类型而非完整限定命名空间，简化对 `ICommand` 和 `IQuery` 的引用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove deprecated context-aware Mediator sync command/query helpers and simplify command/query type usage.

Enhancements:
- Remove legacy synchronous Mediator-based SendCommand and SendQuery extension methods from context-aware extensions.
- Simplify ICommand and IQuery references in context-aware extensions by using direct interface types instead of fully qualified namespaces.

</details>