### PR TITLE
docs(ecs): 更新文档中的类型参数表示和相关链接

### DIFF
--- a/docs/zh-CN/ecs/arch.md
+++ b/docs/zh-CN/ecs/arch.md
@@ -109,7 +109,7 @@ public struct Health(float current, float max)
 
 ### 4. 创建系统
 
-系统继承自 `ArchSystemAdapter<T>`：
+系统继承自 `ArchSystemAdapter&lt;T&gt;`：
 
 ```csharp
 using Arch.Core;
@@ -349,9 +349,9 @@ world.Clear();
 
 ## 系统适配器
 
-### ArchSystemAdapter<T>
+### ArchSystemAdapter&lt;T&gt;
 
-`ArchSystemAdapter<T>` 桥接 Arch.System.ISystem<T> 到 GFramework 架构：
+`ArchSystemAdapter&lt;T&gt;` 桥接 Arch.System.ISystem&lt;T&gt; 到 GFramework 架构：
 
 ```csharp
 public sealed class MySystem : ArchSystemAdapter<float>
@@ -415,7 +415,7 @@ public sealed class MySystem : ArchSystemAdapter<float>
 
 ### 访问框架服务
 
-`ArchSystemAdapter<T>` 继承自 `AbstractSystem`，可以使用所有 GFramework 的扩展方法：
+`ArchSystemAdapter&lt;T&gt;` 继承自 `AbstractSystem`，可以使用所有 GFramework 的扩展方法：
 
 ```csharp
 public sealed class ServiceAccessSystem : ArchSystemAdapter<float>
@@ -743,9 +743,3 @@ protected override void OnUpdate(in float deltaTime)
 
 - [Arch.Core 官方文档](https://github.com/genaray/Arch)
 - [ECS 概述](./index.md)
-- [ECS 最佳实践](./best-practices.md)
-- [性能优化指南](./performance.md)
-
----
-
-**许可证**：MIT License

--- a/docs/zh-CN/ecs/index.md
+++ b/docs/zh-CN/ecs/index.md
@@ -283,15 +283,9 @@ public class ScoreSystem : AbstractSystem
 ## 下一步
 
 - [Arch ECS 集成指南](./arch.md) - 详细的 Arch ECS 使用文档
-- [ECS 最佳实践](./best-practices.md) - ECS 设计模式和优化技巧
-- [性能优化](./performance.md) - ECS 性能优化指南
 
 ## 相关资源
 
 - [Architecture 架构系统](../core/architecture.md)
 - [System 系统](../core/system.md)
 - [事件系统](../core/events.md)
-
----
-
-**许可证**：MIT License


### PR DESCRIPTION
- 将文档中的 `ArchSystemAdapter<T>` 替换为 `ArchSystemAdapter&lt;T&gt;` 以正确显示尖括号
- 移除重复的许可证信息和分隔线
- 删除过时的文档链接，保持导航结构简洁

## Summary by Sourcery

更新 ECS 中文文档，以正确显示泛型类型参数，并精简相关链接和页脚内容。

文档：
- 修正在 ECS Arch 集成指南中 `ArchSystemAdapter<T>` 的泛型类型标注，使尖括号在 HTML 中能够正确渲染。
- 通过从 Arch 页面和索引页中移除过时链接和重复的 MIT 许可部分，简化 ECS 文档导航。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update ECS Chinese documentation to correctly display generic type parameters and streamline related links and footer content.

Documentation:
- Fix generic type notation for ArchSystemAdapter<T> in the ECS Arch integration guide so that angle brackets render correctly in HTML.
- Simplify ECS documentation navigation by removing outdated links and duplicate MIT license sections from the Arch and index pages.

</details>