### PR TITLE
refactor(core): 优化ScopedArray结构体实现

### DIFF
--- a/GFramework.Core/Extensions/ArrayPoolExtensions.cs
+++ b/GFramework.Core/Extensions/ArrayPoolExtensions.cs
@@ -89,7 +89,7 @@ public static class ArrayPoolExtensions
     ///     可自动释放的数组包装器
     /// </summary>
     /// <typeparam name="T">数组元素类型</typeparam>
-    public ref struct ScopedArray<T> : IDisposable
+    public ref struct ScopedArray<T>
     {
         private readonly ArrayPool<T> _pool;
         private readonly bool _clearOnReturn;

--- a/GFramework.Core/Extensions/ArrayPoolExtensions.cs
+++ b/GFramework.Core/Extensions/ArrayPoolExtensions.cs
@@ -89,26 +89,29 @@ public static class ArrayPoolExtensions
     ///     可自动释放的数组包装器
     /// </summary>
     /// <typeparam name="T">数组元素类型</typeparam>
-    public readonly struct ScopedArray<T> : IDisposable
+    public ref struct ScopedArray<T>
     {
         private readonly ArrayPool<T> _pool;
         private readonly bool _clearOnReturn;
+        private T[]? _array;
 
+#pragma warning disable CA1819
         /// <summary>
         ///     获取租用的数组
         /// </summary>
-        public T[] Array { get; }
+        public T[] Array => _array!;
+#pragma warning restore CA1819
 
         /// <summary>
         ///     获取数组的长度
         /// </summary>
-        public int Length => Array.Length;
+        public int Length => _array!.Length;
 
         internal ScopedArray(ArrayPool<T> pool, int minimumLength, bool clearOnReturn)
         {
             _pool = pool;
             _clearOnReturn = clearOnReturn;
-            Array = pool.Rent(minimumLength);
+            _array = pool.Rent(minimumLength);
         }
 
         /// <summary>
@@ -116,14 +119,18 @@ public static class ArrayPoolExtensions
         /// </summary>
         public void Dispose()
         {
-            _pool.Return(Array, _clearOnReturn);
+            if (_array is null)
+                return;
+
+            _pool.Return(_array, _clearOnReturn);
+            _array = null;
         }
 
         /// <summary>
         ///     获取数组的 Span 视图
         /// </summary>
         /// <returns>数组的 Span</returns>
-        public Span<T> AsSpan() => Array.AsSpan();
+        public Span<T> AsSpan() => _array!;
 
         /// <summary>
         ///     获取数组指定范围的 Span 视图
@@ -131,6 +138,14 @@ public static class ArrayPoolExtensions
         /// <param name="start">起始索引</param>
         /// <param name="length">长度</param>
         /// <returns>数组指定范围的 Span</returns>
-        public Span<T> AsSpan(int start, int length) => Array.AsSpan(start, length);
+        public Span<T> AsSpan(int start, int length)
+            => _array!.AsSpan(start, length);
+
+        /// <summary>
+        ///     获取数组指定索引处的引用
+        /// </summary>
+        /// <param name="index">要获取引用的索引位置</param>
+        /// <returns>指定索引处元素的引用</returns>
+        public ref T this[int index] => ref _array![index];
     }
 }

--- a/GFramework.Core/Extensions/ArrayPoolExtensions.cs
+++ b/GFramework.Core/Extensions/ArrayPoolExtensions.cs
@@ -89,7 +89,7 @@ public static class ArrayPoolExtensions
     ///     可自动释放的数组包装器
     /// </summary>
     /// <typeparam name="T">数组元素类型</typeparam>
-    public ref struct ScopedArray<T>
+    public ref struct ScopedArray<T> : IDisposable
     {
         private readonly ArrayPool<T> _pool;
         private readonly bool _clearOnReturn;
@@ -99,13 +99,13 @@ public static class ArrayPoolExtensions
         /// <summary>
         ///     获取租用的数组
         /// </summary>
-        public T[] Array => _array!;
+        public T[] Array => GetArray();
 #pragma warning restore CA1819
 
         /// <summary>
         ///     获取数组的长度
         /// </summary>
-        public int Length => _array!.Length;
+        public int Length => Array.Length;
 
         internal ScopedArray(ArrayPool<T> pool, int minimumLength, bool clearOnReturn)
         {
@@ -130,7 +130,7 @@ public static class ArrayPoolExtensions
         ///     获取数组的 Span 视图
         /// </summary>
         /// <returns>数组的 Span</returns>
-        public Span<T> AsSpan() => _array!;
+        public Span<T> AsSpan() => Array.AsSpan();
 
         /// <summary>
         ///     获取数组指定范围的 Span 视图
@@ -139,13 +139,23 @@ public static class ArrayPoolExtensions
         /// <param name="length">长度</param>
         /// <returns>数组指定范围的 Span</returns>
         public Span<T> AsSpan(int start, int length)
-            => _array!.AsSpan(start, length);
+            => Array.AsSpan(start, length);
 
         /// <summary>
         ///     获取数组指定索引处的引用
         /// </summary>
         /// <param name="index">要获取引用的索引位置</param>
         /// <returns>指定索引处元素的引用</returns>
-        public ref T this[int index] => ref _array![index];
+        public ref T this[int index] => ref Array[index];
+
+        /// <summary>
+        ///     获取内部数组实例
+        /// </summary>
+        /// <returns>内部数组实例</returns>
+        /// <exception cref="ObjectDisposedException">当对象已被丢弃时抛出</exception>
+        private T[] GetArray()
+        {
+            return _array ?? throw new ObjectDisposedException(nameof(ScopedArray<T>));
+        }
     }
 }


### PR DESCRIPTION
- 将ScopedArray从readonly struct改为ref struct以提高性能
- 添加_array字段存储数组引用并移除公共Array属性
- 在Dispose方法中添加空值检查避免重复释放
- 添加Span属性和索引器支持直接访问数组元素
- 使用#pragma warning禁用CA1819警告并优化代码风格

## Summary by Sourcery

优化 `ScopedArray<T>` 的池化数组包装器，以获得更高性能和更安全的生命周期管理。

新特性：
- 在 `ScopedArray<T>` 上公开基于 `Span` 的索引器，通过 `ref` 返回实现对元素的直接访问。

增强改进：
- 将 `ScopedArray<T>` 从 `readonly struct` 更改为 `ref struct`，并将租借的数组存储在私有字段中，以提升性能并提高生命周期安全性。
- 在 `Dispose` 中新增空值保护逻辑，避免将同一数组多次归还到池中，并在归还后清除底层数组引用。
- 直接基于底层数组公开 `Span` 访问器，并对返回数组的属性抑制 CA1819 警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the ScopedArray<T> pooled array wrapper for better performance and safer lifetime management.

New Features:
- Expose a span-based indexer on ScopedArray<T> for direct element access via ref returns.

Enhancements:
- Change ScopedArray<T> from a readonly struct to a ref struct and store the rented array in a private field for improved performance and lifetime safety.
- Add null-guard logic in Dispose to avoid double-returning arrays to the pool and clear the backing array reference after return.
- Expose Span-based accessors directly over the backing array and suppress CA1819 warnings around the array-returning property.

</details>