### PR TITLE
chore(abstractions): 添加 ReSharper 禁用检查命名空间注释

### DIFF
--- a/GFramework.Core.Abstractions/Internals/IsExternalInit.cs
+++ b/GFramework.Core.Abstractions/Internals/IsExternalInit.cs
@@ -5,6 +5,8 @@
 #if !NET5_0_OR_GREATER
 using System.ComponentModel;
 
+// ReSharper disable CheckNamespace
+
 namespace System.Runtime.CompilerServices;
 
 /// <summary>

--- a/GFramework.Game.Abstractions/Internals/IsExternalInit.cs
+++ b/GFramework.Game.Abstractions/Internals/IsExternalInit.cs
@@ -5,6 +5,8 @@
 #if !NET5_0_OR_GREATER
 using System.ComponentModel;
 
+// ReSharper disable CheckNamespace
+
 namespace System.Runtime.CompilerServices;
 
 /// <summary>


### PR DESCRIPTION
- 在 GFramework.Core.Abstractions 中添加 // ReSharper disable CheckNamespace 注释
- 在 GFramework.Game.Abstractions 中添加 // ReSharper disable CheckNamespace 注释
- 解决代码分析工具对命名空间检查的警告问题

## Summary by Sourcery

杂务：
- 在核心和游戏抽象程序集中，为 `IsExternalInit` 文件添加 ReSharper 的 `CheckNamespace` 抑制注释，以避免分析器警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Add ReSharper CheckNamespace suppression comments to IsExternalInit files in core and game abstraction assemblies to avoid analyzer warnings.

</details>