### PR TITLE
Refactor/architecture to architectures namespace

### DIFF
--- a/GFramework.Core.Abstractions/Architectures/ArchitectureModuleRegistry.cs
+++ b/GFramework.Core.Abstractions/Architectures/ArchitectureModuleRegistry.cs
@@ -1,13 +1,13 @@
 using System.Collections.Concurrent;
 
-namespace GFramework.Core.Abstractions.Architecture;
+namespace GFramework.Core.Abstractions.Architectures;
 
 /// <summary>
 ///     架构模块注册表 - 用于外部模块的自动注册
 /// </summary>
 public static class ArchitectureModuleRegistry
 {
-    private static readonly ConcurrentDictionary<string, Func<IServiceModule>> _factories = new();
+    private static readonly ConcurrentDictionary<string, Func<IServiceModule>> Factories = new(StringComparer.Ordinal);
 
     /// <summary>
     ///     注册模块工厂（幂等操作，相同模块名只会注册一次）
@@ -20,7 +20,7 @@ public static class ArchitectureModuleRegistry
         var moduleName = tempModule.ModuleName;
 
         // 幂等注册：相同模块名只注册一次
-        _factories.TryAdd(moduleName, factory);
+        Factories.TryAdd(moduleName, factory);
     }
 
     /// <summary>
@@ -29,7 +29,7 @@ public static class ArchitectureModuleRegistry
     /// <returns>模块实例集合</returns>
     public static IEnumerable<IServiceModule> CreateModules()
     {
-        return _factories.Values.Select(f => f());
+        return Factories.Values.Select(f => f());
     }
 
     /// <summary>
@@ -37,6 +37,6 @@ public static class ArchitectureModuleRegistry
     /// </summary>
     public static void Clear()
     {
-        _factories.Clear();
+        Factories.Clear();
     }
 }

--- a/GFramework.Core.Abstractions/Architectures/IArchitecture.cs
+++ b/GFramework.Core.Abstractions/Architectures/IArchitecture.cs
@@ -4,7 +4,7 @@ using GFramework.Core.Abstractions.Systems;
 using GFramework.Core.Abstractions.Utility;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace GFramework.Core.Abstractions.Architecture;
+namespace GFramework.Core.Abstractions.Architectures;
 
 /// <summary>
 ///     架构接口，专注于生命周期管理，包括系统、模型、工具的注册和获取

--- a/GFramework.Core.Abstractions/Architectures/IArchitectureConfiguration.cs
+++ b/GFramework.Core.Abstractions/Architectures/IArchitectureConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿using GFramework.Core.Abstractions.Properties;
 
-namespace GFramework.Core.Abstractions.Architecture;
+namespace GFramework.Core.Abstractions.Architectures;
 
 /// <summary>
 ///     定义架构配置的接口，提供日志工厂、日志级别和架构选项的配置功能

--- a/GFramework.Core.Abstractions/Architectures/IArchitectureContext.cs
+++ b/GFramework.Core.Abstractions/Architectures/IArchitectureContext.cs
@@ -8,7 +8,7 @@ using GFramework.Core.Abstractions.Utility;
 using Mediator;
 using ICommand = GFramework.Core.Abstractions.Command.ICommand;
 
-namespace GFramework.Core.Abstractions.Architecture;
+namespace GFramework.Core.Abstractions.Architectures;
 
 /// <summary>
 ///     架构上下文接口，提供对系统、模型、工具类的访问以及命令、查询、事件的发送和注册功能

--- a/GFramework.Core.Abstractions/Architectures/IArchitectureContextProvider.cs
+++ b/GFramework.Core.Abstractions/Architectures/IArchitectureContextProvider.cs
@@ -1,4 +1,4 @@
-namespace GFramework.Core.Abstractions.Architecture;
+namespace GFramework.Core.Abstractions.Architectures;
 
 /// <summary>
 /// 架构上下文提供者接口，用于解耦上下文获取逻辑

--- a/GFramework.Core.Abstractions/Architectures/IArchitectureLifecycleHook.cs
+++ b/GFramework.Core.Abstractions/Architectures/IArchitectureLifecycleHook.cs
@@ -1,6 +1,6 @@
 ﻿using GFramework.Core.Abstractions.Enums;
 
-namespace GFramework.Core.Abstractions.Architecture;
+namespace GFramework.Core.Abstractions.Architectures;
 
 /// <summary>
 /// 架构生命周期钩子接口，用于在架构的不同生命周期阶段执行自定义逻辑。

--- a/GFramework.Core.Abstractions/Architectures/IArchitectureModule.cs
+++ b/GFramework.Core.Abstractions/Architectures/IArchitectureModule.cs
@@ -1,4 +1,4 @@
-﻿namespace GFramework.Core.Abstractions.Architecture;
+﻿namespace GFramework.Core.Abstractions.Architectures;
 
 /// <summary>
 ///     架构模块接口，继承自架构生命周期接口。

--- a/GFramework.Core.Abstractions/Architectures/IArchitecturePhaseListener.cs
+++ b/GFramework.Core.Abstractions/Architectures/IArchitecturePhaseListener.cs
@@ -1,6 +1,6 @@
 ﻿using GFramework.Core.Abstractions.Enums;
 
-namespace GFramework.Core.Abstractions.Architecture;
+namespace GFramework.Core.Abstractions.Architectures;
 
 /// <summary>
 /// 架构阶段监听器接口，用于监听和响应架构生命周期中的不同阶段变化。

--- a/GFramework.Core.Abstractions/Architectures/IArchitectureServices.cs
+++ b/GFramework.Core.Abstractions/Architectures/IArchitectureServices.cs
@@ -4,7 +4,7 @@ using GFramework.Core.Abstractions.Ioc;
 using GFramework.Core.Abstractions.Query;
 using GFramework.Core.Abstractions.Rule;
 
-namespace GFramework.Core.Abstractions.Architecture;
+namespace GFramework.Core.Abstractions.Architectures;
 
 /// <summary>
 ///     架构服务接口，定义了框架核心架构所需的服务组件

--- a/GFramework.Core.Abstractions/Architectures/IServiceModule.cs
+++ b/GFramework.Core.Abstractions/Architectures/IServiceModule.cs
@@ -1,7 +1,7 @@
 using GFramework.Core.Abstractions.Ioc;
 using GFramework.Core.Abstractions.Lifecycle;
 
-namespace GFramework.Core.Abstractions.Architecture;
+namespace GFramework.Core.Abstractions.Architectures;
 
 /// <summary>
 ///     服务模块接口，定义了服务模块的基本契约。

--- a/GFramework.Core.Abstractions/Architectures/IServiceModuleManager.cs
+++ b/GFramework.Core.Abstractions/Architectures/IServiceModuleManager.cs
@@ -1,6 +1,6 @@
 using GFramework.Core.Abstractions.Ioc;
 
-namespace GFramework.Core.Abstractions.Architecture;
+namespace GFramework.Core.Abstractions.Architectures;
 
 /// <summary>
 ///     服务模块管理器接口，用于管理架构中的服务模块。

--- a/GFramework.Core.Abstractions/Model/IModel.cs
+++ b/GFramework.Core.Abstractions/Model/IModel.cs
@@ -1,4 +1,4 @@
-﻿using GFramework.Core.Abstractions.Architecture;
+﻿using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Lifecycle;
 using GFramework.Core.Abstractions.Rule;
 

--- a/GFramework.Core.Abstractions/Rule/IContextAware.cs
+++ b/GFramework.Core.Abstractions/Rule/IContextAware.cs
@@ -1,4 +1,4 @@
-﻿using GFramework.Core.Abstractions.Architecture;
+﻿using GFramework.Core.Abstractions.Architectures;
 
 namespace GFramework.Core.Abstractions.Rule;
 

--- a/GFramework.Core.Abstractions/Systems/ISystem.cs
+++ b/GFramework.Core.Abstractions/Systems/ISystem.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Lifecycle;
 using GFramework.Core.Abstractions.Rule;
 

--- a/GFramework.Core.Tests/Architectures/ArchitectureConfigurationTests.cs
+++ b/GFramework.Core.Tests/Architectures/ArchitectureConfigurationTests.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Logging;
 using GFramework.Core.Abstractions.Properties;
 using GFramework.Core.Architectures;

--- a/GFramework.Core.Tests/Architectures/ArchitectureContextTests.cs
+++ b/GFramework.Core.Tests/Architectures/ArchitectureContextTests.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Command;
 using GFramework.Core.Abstractions.Enums;
 using GFramework.Core.Abstractions.Environment;

--- a/GFramework.Core.Tests/Architectures/ArchitectureServicesTests.cs
+++ b/GFramework.Core.Tests/Architectures/ArchitectureServicesTests.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Command;
 using GFramework.Core.Abstractions.Environment;
 using GFramework.Core.Abstractions.Events;

--- a/GFramework.Core.Tests/Architectures/ContextProviderTests.cs
+++ b/GFramework.Core.Tests/Architectures/ContextProviderTests.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Architectures;
 
 namespace GFramework.Core.Tests.Architectures;

--- a/GFramework.Core.Tests/Architectures/GameContextTests.cs
+++ b/GFramework.Core.Tests/Architectures/GameContextTests.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Command;
 using GFramework.Core.Abstractions.Environment;
 using GFramework.Core.Abstractions.Events;

--- a/GFramework.Core.Tests/Architectures/RegistryInitializationHookBaseTests.cs
+++ b/GFramework.Core.Tests/Architectures/RegistryInitializationHookBaseTests.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Enums;
 using GFramework.Core.Abstractions.Lifecycle;
 using GFramework.Core.Abstractions.Model;

--- a/GFramework.Core.Tests/Coroutine/CommandCoroutineExtensionsTests.cs
+++ b/GFramework.Core.Tests/Coroutine/CommandCoroutineExtensionsTests.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Command;
 using GFramework.Core.Abstractions.Coroutine;
 using GFramework.Core.Abstractions.Events;
@@ -6,7 +6,6 @@ using GFramework.Core.Abstractions.Rule;
 using GFramework.Core.Coroutine.Extensions;
 using GFramework.Core.Coroutine.Instructions;
 using Moq;
-using NUnit.Framework;
 
 namespace GFramework.Core.Tests.Coroutine;
 

--- a/GFramework.Core.Tests/Coroutine/MediatorCoroutineExtensionsTests.cs
+++ b/GFramework.Core.Tests/Coroutine/MediatorCoroutineExtensionsTests.cs
@@ -11,13 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Coroutine;
 using GFramework.Core.Abstractions.Rule;
 using GFramework.Core.Coroutine.Extensions;
 using Mediator;
 using Moq;
-using NUnit.Framework;
 
 namespace GFramework.Core.Tests.Coroutine;
 

--- a/GFramework.Core.Tests/Coroutine/QueryCoroutineExtensionsTests.cs
+++ b/GFramework.Core.Tests/Coroutine/QueryCoroutineExtensionsTests.cs
@@ -1,10 +1,9 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Coroutine;
 using GFramework.Core.Abstractions.Query;
 using GFramework.Core.Abstractions.Rule;
 using GFramework.Core.Coroutine.Extensions;
 using Moq;
-using NUnit.Framework;
 
 namespace GFramework.Core.Tests.Coroutine;
 

--- a/GFramework.Core.Tests/Mediator/MediatorArchitectureIntegrationTests.cs
+++ b/GFramework.Core.Tests/Mediator/MediatorArchitectureIntegrationTests.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Architectures;
 using GFramework.Core.Command;
 using GFramework.Core.Ioc;

--- a/GFramework.Core.Tests/Mediator/MediatorComprehensiveTests.cs
+++ b/GFramework.Core.Tests/Mediator/MediatorComprehensiveTests.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Events;
 using GFramework.Core.Architectures;
 using GFramework.Core.Command;

--- a/GFramework.Core.Tests/Model/FailingModel.cs
+++ b/GFramework.Core.Tests/Model/FailingModel.cs
@@ -1,4 +1,4 @@
-﻿using GFramework.Core.Abstractions.Architecture;
+﻿using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Enums;
 using GFramework.Core.Abstractions.Model;
 

--- a/GFramework.Core.Tests/Rule/ContextAwareServiceExtensionsTests.cs
+++ b/GFramework.Core.Tests/Rule/ContextAwareServiceExtensionsTests.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Enums;
 using GFramework.Core.Abstractions.Model;
 using GFramework.Core.Abstractions.Rule;

--- a/GFramework.Core.Tests/Rule/ContextAwareTests.cs
+++ b/GFramework.Core.Tests/Rule/ContextAwareTests.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Rule;
 using GFramework.Core.Architectures;
 using GFramework.Core.Rule;

--- a/GFramework.Core.Tests/Systems/AsyncTestSystem.cs
+++ b/GFramework.Core.Tests/Systems/AsyncTestSystem.cs
@@ -1,4 +1,4 @@
-﻿using GFramework.Core.Abstractions.Architecture;
+﻿using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Enums;
 using GFramework.Core.Abstractions.Lifecycle;
 using GFramework.Core.Abstractions.Systems;

--- a/GFramework.Core.Tests/Systems/TestSystem.cs
+++ b/GFramework.Core.Tests/Systems/TestSystem.cs
@@ -1,4 +1,4 @@
-﻿using GFramework.Core.Abstractions.Architecture;
+﻿using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Enums;
 using GFramework.Core.Abstractions.Systems;
 

--- a/GFramework.Core/Architectures/Architecture.cs
+++ b/GFramework.Core/Architectures/Architecture.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Enums;
 using GFramework.Core.Abstractions.Environment;
 using GFramework.Core.Abstractions.Ioc;

--- a/GFramework.Core/Architectures/ArchitectureConfiguration.cs
+++ b/GFramework.Core/Architectures/ArchitectureConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using GFramework.Core.Abstractions.Architecture;
+﻿using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Logging;
 using GFramework.Core.Abstractions.Properties;
 using GFramework.Core.Logging;

--- a/GFramework.Core/Architectures/ArchitectureContext.cs
+++ b/GFramework.Core/Architectures/ArchitectureContext.cs
@@ -1,5 +1,5 @@
 using System.Collections.Concurrent;
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Command;
 using GFramework.Core.Abstractions.Environment;
 using GFramework.Core.Abstractions.Events;

--- a/GFramework.Core/Architectures/ArchitectureServices.cs
+++ b/GFramework.Core/Architectures/ArchitectureServices.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Command;
 using GFramework.Core.Abstractions.Events;
 using GFramework.Core.Abstractions.Ioc;

--- a/GFramework.Core/Architectures/GameContext.cs
+++ b/GFramework.Core/Architectures/GameContext.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Concurrent;
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 
 namespace GFramework.Core.Architectures;
 

--- a/GFramework.Core/Architectures/GameContextProvider.cs
+++ b/GFramework.Core/Architectures/GameContextProvider.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 
 namespace GFramework.Core.Architectures;
 

--- a/GFramework.Core/Architectures/RegistryInitializationHookBase.cs
+++ b/GFramework.Core/Architectures/RegistryInitializationHookBase.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Enums;
 using GFramework.Core.Abstractions.Utility;
 

--- a/GFramework.Core/Architectures/ScopedContextProvider.cs
+++ b/GFramework.Core/Architectures/ScopedContextProvider.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 
 namespace GFramework.Core.Architectures;
 

--- a/GFramework.Core/Rule/ContextAwareBase.cs
+++ b/GFramework.Core/Rule/ContextAwareBase.cs
@@ -1,4 +1,4 @@
-﻿using GFramework.Core.Abstractions.Architecture;
+﻿using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Rule;
 using GFramework.Core.Architectures;
 

--- a/GFramework.Core/Services/Modules/AsyncQueryExecutorModule.cs
+++ b/GFramework.Core/Services/Modules/AsyncQueryExecutorModule.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Ioc;
 using GFramework.Core.Query;
 

--- a/GFramework.Core/Services/Modules/CommandExecutorModule.cs
+++ b/GFramework.Core/Services/Modules/CommandExecutorModule.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Ioc;
 using GFramework.Core.Command;
 

--- a/GFramework.Core/Services/Modules/EventBusModule.cs
+++ b/GFramework.Core/Services/Modules/EventBusModule.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Ioc;
 using GFramework.Core.Events;
 

--- a/GFramework.Core/Services/Modules/QueryExecutorModule.cs
+++ b/GFramework.Core/Services/Modules/QueryExecutorModule.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Ioc;
 using GFramework.Core.Query;
 

--- a/GFramework.Core/Services/ServiceModuleManager.cs
+++ b/GFramework.Core/Services/ServiceModuleManager.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Ioc;
 using GFramework.Core.Abstractions.Lifecycle;
 using GFramework.Core.Abstractions.Logging;

--- a/GFramework.Core/State/AsyncContextAwareStateBase.cs
+++ b/GFramework.Core/State/AsyncContextAwareStateBase.cs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Lifecycle;
 using GFramework.Core.Abstractions.Rule;
 using GFramework.Core.Abstractions.State;

--- a/GFramework.Core/State/ContextAwareStateBase.cs
+++ b/GFramework.Core/State/ContextAwareStateBase.cs
@@ -1,4 +1,4 @@
-﻿using GFramework.Core.Abstractions.Architecture;
+﻿using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Lifecycle;
 using GFramework.Core.Abstractions.Rule;
 using GFramework.Core.Abstractions.State;

--- a/GFramework.Core/State/StateMachineSystem.cs
+++ b/GFramework.Core/State/StateMachineSystem.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Enums;
 using GFramework.Core.Abstractions.Lifecycle;
 using GFramework.Core.Abstractions.Rule;

--- a/GFramework.Ecs.Arch.Abstractions/IArchEcsModule.cs
+++ b/GFramework.Ecs.Arch.Abstractions/IArchEcsModule.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 
 namespace GFramework.Ecs.Arch.Abstractions;
 

--- a/GFramework.Ecs.Arch.Tests/Integration/ExplicitRegistrationTests.cs
+++ b/GFramework.Ecs.Arch.Tests/Integration/ExplicitRegistrationTests.cs
@@ -1,5 +1,5 @@
 using Arch.Core;
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Architectures;
 using GFramework.Core.Ioc;
 using GFramework.Ecs.Arch.Abstractions;

--- a/GFramework.Ecs.Arch/Extensions/ArchExtensions.cs
+++ b/GFramework.Ecs.Arch/Extensions/ArchExtensions.cs
@@ -1,4 +1,4 @@
-using GFramework.Core.Abstractions.Architecture;
+using GFramework.Core.Abstractions.Architectures;
 
 namespace GFramework.Ecs.Arch.Extensions;
 

--- a/GFramework.Godot/Architecture/AbstractArchitecture.cs
+++ b/GFramework.Godot/Architecture/AbstractArchitecture.cs
@@ -1,4 +1,4 @@
-﻿using GFramework.Core.Abstractions.Architecture;
+﻿using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Environment;
 using GFramework.Core.Constants;
 using GFramework.Godot.Extensions;

--- a/GFramework.Godot/Architecture/AbstractGodotModule.cs
+++ b/GFramework.Godot/Architecture/AbstractGodotModule.cs
@@ -1,4 +1,4 @@
-﻿using GFramework.Core.Abstractions.Architecture;
+﻿using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Enums;
 using Godot;
 

--- a/GFramework.Godot/Architecture/IGodotModule.cs
+++ b/GFramework.Godot/Architecture/IGodotModule.cs
@@ -1,4 +1,4 @@
-﻿using GFramework.Core.Abstractions.Architecture;
+﻿using GFramework.Core.Abstractions.Architectures;
 using Godot;
 
 namespace GFramework.Godot.Architecture;

--- a/GFramework.Godot/Architectures/AbstractArchitecture.cs
+++ b/GFramework.Godot/Architectures/AbstractArchitecture.cs
@@ -1,10 +1,11 @@
 ﻿using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Environment;
+using GFramework.Core.Architectures;
 using GFramework.Core.Constants;
 using GFramework.Godot.Extensions;
 using Godot;
 
-namespace GFramework.Godot.Architecture;
+namespace GFramework.Godot.Architectures;
 
 /// <summary>
 ///     抽象架构类，为特定类型的架构提供基础实现框架。
@@ -15,7 +16,7 @@ public abstract class AbstractArchitecture(
     IEnvironment? environment = null,
     IArchitectureServices? services = null,
     IArchitectureContext? context = null
-) : Core.Architectures.Architecture(configuration, environment, services, context)
+) : Architecture(configuration, environment, services, context)
 {
     /// <summary>
     ///     存储所有已安装的Godot架构扩展组件列表

--- a/GFramework.Godot/Architectures/AbstractGodotModule.cs
+++ b/GFramework.Godot/Architectures/AbstractGodotModule.cs
@@ -1,8 +1,9 @@
 ﻿using GFramework.Core.Abstractions.Architectures;
 using GFramework.Core.Abstractions.Enums;
+using GFramework.Core.Architectures;
 using Godot;
 
-namespace GFramework.Godot.Architecture;
+namespace GFramework.Godot.Architectures;
 
 /// <summary>
 ///     抽象的Godot模块基类，用于定义Godot框架中的模块行为
@@ -31,7 +32,7 @@ public abstract class AbstractGodotModule : IGodotModule
     ///     当模块被附加到架构时调用此方法
     /// </summary>
     /// <param name="architecture">被附加到的架构实例</param>
-    public virtual void OnAttach(Core.Architectures.Architecture architecture)
+    public virtual void OnAttach(Architecture architecture)
     {
     }
 

--- a/GFramework.Godot/Architectures/ArchitectureAnchor.cs
+++ b/GFramework.Godot/Architectures/ArchitectureAnchor.cs
@@ -1,6 +1,6 @@
 ﻿using Godot;
 
-namespace GFramework.Godot.Architecture;
+namespace GFramework.Godot.Architectures;
 
 /// <summary>
 ///     架构锚点节点类，用于在Godot场景树中作为架构组件的根节点

--- a/GFramework.Godot/Architectures/IGodotModule.cs
+++ b/GFramework.Godot/Architectures/IGodotModule.cs
@@ -1,7 +1,8 @@
 ﻿using GFramework.Core.Abstractions.Architectures;
+using GFramework.Core.Architectures;
 using Godot;
 
-namespace GFramework.Godot.Architecture;
+namespace GFramework.Godot.Architectures;
 
 /// <summary>
 ///     Godot模块接口，定义了Godot引擎中模块的基本行为和属性
@@ -17,7 +18,7 @@ public interface IGodotModule : IArchitectureModule
     ///     当模块被附加到架构时调用
     /// </summary>
     /// <param name="architecture">要附加到的架构实例</param>
-    void OnAttach(Core.Architectures.Architecture architecture);
+    void OnAttach(Architecture architecture);
 
     /// <summary>
     ///     当模块从架构分离时调用

--- a/GFramework.SourceGenerators.Tests/Rule/ContextAwareGeneratorSnapshotTests.cs
+++ b/GFramework.SourceGenerators.Tests/Rule/ContextAwareGeneratorSnapshotTests.cs
@@ -35,13 +35,13 @@ public class ContextAwareGeneratorSnapshotTests
                                   public interface IContextAware
                                   {
                                       void SetContext(
-                                          GFramework.Core.Abstractions.Architecture.IArchitectureContext context);
+                                          GFramework.Core.Abstractions.Architectures.IArchitectureContext context);
 
-                                      GFramework.Core.Abstractions.Architecture.IArchitectureContext GetContext();
+                                      GFramework.Core.Abstractions.Architectures.IArchitectureContext GetContext();
                                   }
                               }
 
-                              namespace GFramework.Core.Abstractions.Architecture
+                              namespace GFramework.Core.Abstractions.Architectures
                               {
                                   public interface IArchitectureContext { }
 
@@ -52,9 +52,9 @@ public class ContextAwareGeneratorSnapshotTests
                                   }
                               }
 
-                              namespace GFramework.Core.Architecture
+                              namespace GFramework.Core.Architectures
                               {
-                                  using GFramework.Core.Abstractions.Architecture;
+                                  using GFramework.Core.Abstractions.Architectures;
 
                                   public sealed class GameContextProvider : IArchitectureContextProvider
                                   {

--- a/GFramework.SourceGenerators/Rule/ContextAwareGenerator.cs
+++ b/GFramework.SourceGenerators/Rule/ContextAwareGenerator.cs
@@ -129,21 +129,21 @@ public sealed class ContextAwareGenerator : MetadataAttributeClassGeneratorBase
     /// <param name="sb">字符串构建器</param>
     private static void GenerateContextProperty(StringBuilder sb)
     {
-        sb.AppendLine("    private global::GFramework.Core.Abstractions.Architecture.IArchitectureContext? _context;");
+        sb.AppendLine("    private global::GFramework.Core.Abstractions.Architectures.IArchitectureContext? _context;");
         sb.AppendLine(
-            "    private static global::GFramework.Core.Abstractions.Architecture.IArchitectureContextProvider? _contextProvider;");
+            "    private static global::GFramework.Core.Abstractions.Architectures.IArchitectureContextProvider? _contextProvider;");
         sb.AppendLine();
         sb.AppendLine("    /// <summary>");
         sb.AppendLine("    /// 自动获取的架构上下文（懒加载，默认使用 GameContextProvider）");
         sb.AppendLine("    /// </summary>");
-        sb.AppendLine("    protected global::GFramework.Core.Abstractions.Architecture.IArchitectureContext Context");
+        sb.AppendLine("    protected global::GFramework.Core.Abstractions.Architectures.IArchitectureContext Context");
         sb.AppendLine("    {");
         sb.AppendLine("        get");
         sb.AppendLine("        {");
         sb.AppendLine("            if (_context == null)");
         sb.AppendLine("            {");
         sb.AppendLine(
-            "                _contextProvider ??= new global::GFramework.Core.Architecture.GameContextProvider();");
+            "                _contextProvider ??= new global::GFramework.Core.Architectures.GameContextProvider();");
         sb.AppendLine("                _context = _contextProvider.GetContext();");
         sb.AppendLine("            }");
         sb.AppendLine();
@@ -156,7 +156,7 @@ public sealed class ContextAwareGenerator : MetadataAttributeClassGeneratorBase
         sb.AppendLine("    /// </summary>");
         sb.AppendLine("    /// <param name=\"provider\">上下文提供者实例</param>");
         sb.AppendLine(
-            "    public static void SetContextProvider(global::GFramework.Core.Abstractions.Architecture.IArchitectureContextProvider provider)");
+            "    public static void SetContextProvider(global::GFramework.Core.Abstractions.Architectures.IArchitectureContextProvider provider)");
         sb.AppendLine("    {");
         sb.AppendLine("        _contextProvider = provider;");
         sb.AppendLine("    }");


### PR DESCRIPTION
## Summary by Sourcery

将与架构相关的抽象和实现，从单数形式的 `Architecture` 命名空间迁移到复数形式的 `Architectures` 命名空间，覆盖 core、Godot、ECS、源代码生成器以及测试等部分。

Enhancements:
- 更新 `Architecture` 模块注册表，使用具名、区分大小写的工厂字典，并以 Ordinal 字符串比较作为键的比较方式。
- 使 Godot 和 ECS 的集成类型及扩展与新的 `Architectures` 命名空间结构保持一致。

Tests:
- 调整现有的单元测试和集成测试以引用新的 `Architectures` 命名空间，而不改变测试行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move architecture-related abstractions and implementations from the singular Architecture namespace to a plural Architectures namespace across core, Godot, ECS, source generators, and tests.

Enhancements:
- Update Architecture module registry to use a named, case-sensitive factory dictionary keyed with Ordinal string comparison.
- Align Godot and ECS integration types and extensions with the new Architectures namespace structure.

Tests:
- Adjust existing unit and integration tests to reference the new Architectures namespaces without changing test behavior.

</details>