### PR TITLE
chore(deps): 更新 Mediator.Abstractions 包版本

### DIFF
--- a/GFramework.Core.Tests/GFramework.Core.Tests.csproj
+++ b/GFramework.Core.Tests/GFramework.Core.Tests.csproj
@@ -10,7 +10,7 @@
         <WarningLevel>0</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Mediator.Abstractions" Version="3.0.1"/>
+        <PackageReference Include="Mediator.Abstractions" Version="3.0.2"/>
         <PackageReference Include="Mediator.SourceGenerator" Version="3.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- 将 Mediator.Abstractions 从 3.0.1 升级到 3.0.2 版本

## Summary by Sourcery

维护杂项：
- 在测试项目的依赖配置中，将 `Mediator.Abstractions` 包从 3.0.1 更新到 3.0.2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Update Mediator.Abstractions package from 3.0.1 to 3.0.2 in the test project dependency configuration.

</details>