### PR TITLE
feat(workflow): 添加许可证合规检查工作流并优化发布流程

### DIFF
--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -114,4 +118,4 @@ jobs:
             sbom-cyclonedx-validation.txt
             license-compliance.zip
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   packages: write
@@ -78,19 +82,6 @@ jobs:
         with:
           name: packages
           path: ./packages/*.nupkg
-
-      # 上传许可证合规相关的工件文件，包括通知文件、第三方许可证、SBOM 文件及验证结果。
-      - name: Upload compliance artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: license-compliance
-          path: |
-            NOTICE
-            THIRD_PARTY_LICENSES.md
-            sbom.spdx.json
-            sbom.cyclonedx.json
-            sbom-spdx-validation.txt
-            sbom-cyclonedx-validation.txt
 
   publish-nuget:
     name: Publish To NuGet.org
@@ -215,13 +206,8 @@ jobs:
           name: packages
           path: ./packages
 
-      - name: Download compliance artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: license-compliance
-          path: .
-
-      # 无论某一侧包源发布是否失败，都继续创建 Release，并在正文中标注结果。
+      # 无论某一侧包源发布是否失败，都继续创建 Release。
+      # 合规工件由独立 workflow 生成，当前发布流不再假设这些文件在同一次运行中可用。
       - name: Create GitHub Release and Upload Assets
         uses: softprops/action-gh-release@v2
         with:
@@ -230,20 +216,9 @@ jobs:
           body: |
             Release created by CI for tag ${{ github.ref_name }}
             Package version: ${{ needs.build-pack.outputs.package_version }}
-
-            ## Compliance
-            - NOTICE
-            - THIRD_PARTY_LICENSES
-            - SPDX & CycloneDX SBOM
           draft: false
           prerelease: false
           files: |
             ./packages/*.nupkg
-            NOTICE
-            THIRD_PARTY_LICENSES.md
-            sbom.spdx.json
-            sbom.cyclonedx.json
-            sbom-spdx-validation.txt
-            sbom-cyclonedx-validation.txt
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- 新增 license-compliance.yml 工作流，集成 Feluda 许可证扫描器
- 实现许可证合规性检查、SBOM 生成和验证功能
- 移除 publish.yml 中的许可证合规相关步骤
- 更新发布流程以分离许可证合规和包发布职责
- 添加并发控制配置避免重复执行
- 简化 GitHub Release 创建流程，移除合规文件附件逻辑

## Summary by Sourcery

将许可证合规处理从发布工作流中分离出来，并简化发布创建流程。

增强内容：
- 为发布（publish）工作流添加并发控制，避免对同一 ref 进行重复运行。
- 将 GitHub Release 的创建与许可证合规制品解耦，并简化附加资源和发布正文内容。
- 使许可证合规工作流中令牌的使用与标准 GitHub 上下文令牌保持一致。
- 为许可证合规工作流添加并发控制，避免对同一 ref 进行重复运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate license compliance handling from the publish workflow and streamline release creation.

Enhancements:
- Add concurrency control to the publish workflow to avoid duplicate runs for the same ref.
- Decouple GitHub Release creation from license compliance artifacts and simplify attached assets and release body content.
- Align the license compliance workflow token usage with the standard GitHub context token.
- Add concurrency control to the license compliance workflow to avoid duplicate runs for the same ref.

</details>