### PR TITLE
docs(config): 添加游戏内容配置系统完整文档和诊断规则

### DIFF
--- a/GFramework.Game.Tests/Config/YamlConfigLoaderTests.cs
+++ b/GFramework.Game.Tests/Config/YamlConfigLoaderTests.cs
@@ -832,6 +832,164 @@ public class YamlConfigLoaderTests
     }
 
     /// <summary>
+    ///     验证运行时会接受当前共享支持的字符串 <c>format</c> 子集。
+    /// </summary>
+    /// <param name="formatName">schema 中声明的 format 名称。</param>
+    /// <param name="value">满足该 format 的 YAML 标量值。</param>
+    [TestCase("date", "2026-04-11")]
+    [TestCase("date-time", "2026-04-11T08:30:00Z")]
+    [TestCase("email", "boss@example.com")]
+    [TestCase("uri", "https://example.com/loot-table")]
+    [TestCase("uuid", "123e4567-e89b-12d3-a456-426614174000")]
+    public async Task LoadAsync_Should_Accept_Supported_String_Format(
+        string formatName,
+        string value)
+    {
+        CreateConfigFile(
+            "monster/slime.yaml",
+            $$"""
+              id: 1
+              name: {{value}}
+              hp: 10
+              """);
+        CreateSchemaFile(
+            "schemas/monster.schema.json",
+            $$"""
+              {
+                "type": "object",
+                "required": ["id", "name", "hp"],
+                "properties": {
+                  "id": { "type": "integer" },
+                  "name": {
+                    "type": "string",
+                    "format": "{{formatName}}"
+                  },
+                  "hp": { "type": "integer" }
+                }
+              }
+              """);
+
+        var loader = new YamlConfigLoader(_rootPath)
+            .RegisterTable<int, MonsterConfigStub>("monster", "monster", "schemas/monster.schema.json",
+                static config => config.Id);
+        var registry = new ConfigRegistry();
+
+        await loader.LoadAsync(registry);
+
+        var table = registry.GetTable<int, MonsterConfigStub>("monster");
+        Assert.Multiple(() =>
+        {
+            Assert.That(table.Count, Is.EqualTo(1));
+            Assert.That(table.Get(1).Name, Is.EqualTo(value));
+        });
+    }
+
+    /// <summary>
+    ///     验证运行时会拒绝不满足共享字符串 <c>format</c> 子集的值。
+    /// </summary>
+    /// <param name="formatName">schema 中声明的 format 名称。</param>
+    /// <param name="value">不满足该 format 的 YAML 标量值。</param>
+    [TestCase("date", "2026-02-30")]
+    [TestCase("date-time", "2026-04-11T08:30:00")]
+    [TestCase("email", "boss.example.com")]
+    [TestCase("uri", "/loot-table")]
+    [TestCase("uuid", "123e4567e89b12d3a456426614174000")]
+    public void LoadAsync_Should_Throw_When_String_Does_Not_Match_Supported_Format(
+        string formatName,
+        string value)
+    {
+        CreateConfigFile(
+            "monster/slime.yaml",
+            $$"""
+              id: 1
+              name: {{value}}
+              hp: 10
+              """);
+        CreateSchemaFile(
+            "schemas/monster.schema.json",
+            $$"""
+              {
+                "type": "object",
+                "required": ["id", "name", "hp"],
+                "properties": {
+                  "id": { "type": "integer" },
+                  "name": {
+                    "type": "string",
+                    "format": "{{formatName}}"
+                  },
+                  "hp": { "type": "integer" }
+                }
+              }
+              """);
+
+        var loader = new YamlConfigLoader(_rootPath)
+            .RegisterTable<int, MonsterConfigStub>("monster", "monster", "schemas/monster.schema.json",
+                static config => config.Id);
+        var registry = new ConfigRegistry();
+
+        var exception = Assert.ThrowsAsync<ConfigLoadException>(async () => await loader.LoadAsync(registry));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception, Is.Not.Null);
+            Assert.That(exception!.Diagnostic.FailureKind, Is.EqualTo(ConfigLoadFailureKind.ConstraintViolation));
+            Assert.That(exception.Diagnostic.DisplayPath, Is.EqualTo("name"));
+            Assert.That(exception.Diagnostic.RawValue, Is.EqualTo(value));
+            Assert.That(exception.Message, Does.Contain("string format"));
+            Assert.That(exception.Message, Does.Contain(formatName));
+            Assert.That(registry.Count, Is.EqualTo(0));
+        });
+    }
+
+    /// <summary>
+    ///     验证 schema 使用当前未支持的字符串 <c>format</c> 时会在解析阶段被拒绝。
+    /// </summary>
+    [Test]
+    public void LoadAsync_Should_Throw_When_String_Format_Is_Not_Supported()
+    {
+        CreateConfigFile(
+            "monster/slime.yaml",
+            """
+            id: 1
+            name: Slime
+            hp: 10
+            """);
+        CreateSchemaFile(
+            "schemas/monster.schema.json",
+            """
+            {
+              "type": "object",
+              "required": ["id", "name", "hp"],
+              "properties": {
+                "id": { "type": "integer" },
+                "name": {
+                  "type": "string",
+                  "format": "ipv4"
+                },
+                "hp": { "type": "integer" }
+              }
+            }
+            """);
+
+        var loader = new YamlConfigLoader(_rootPath)
+            .RegisterTable<int, MonsterConfigStub>("monster", "monster", "schemas/monster.schema.json",
+                static config => config.Id);
+        var registry = new ConfigRegistry();
+
+        var exception = Assert.ThrowsAsync<ConfigLoadException>(async () => await loader.LoadAsync(registry));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception, Is.Not.Null);
+            Assert.That(exception!.Diagnostic.FailureKind, Is.EqualTo(ConfigLoadFailureKind.SchemaUnsupported));
+            Assert.That(exception.Diagnostic.DisplayPath, Is.EqualTo("name"));
+            Assert.That(exception.Diagnostic.RawValue, Is.EqualTo("ipv4"));
+            Assert.That(exception.Message, Does.Contain("unsupported string format"));
+            Assert.That(exception.Message, Does.Contain("date-time"));
+        });
+    }
+
+    /// <summary>
     ///     验证运行时 schema 校验与 JS 工具对反向引用模式保持一致。
     /// </summary>
     [Test]

--- a/GFramework.Game.Tests/Config/YamlConfigLoaderTests.cs
+++ b/GFramework.Game.Tests/Config/YamlConfigLoaderTests.cs
@@ -990,6 +990,96 @@ public class YamlConfigLoaderTests
     }
 
     /// <summary>
+    ///     验证 schema 在非字符串节点上声明 <c>format</c> 时，会在 schema 解析阶段被拒绝。
+    /// </summary>
+    [Test]
+    public void LoadAsync_Should_Throw_When_Format_Is_Used_On_Non_String_Property()
+    {
+        CreateConfigFile(
+            "monster/slime.yaml",
+            """
+            id: 1
+            hp: 10
+            """);
+        CreateSchemaFile(
+            "schemas/monster.schema.json",
+            """
+            {
+              "type": "object",
+              "required": ["id", "hp"],
+              "properties": {
+                "id": { "type": "integer" },
+                "hp": {
+                  "type": "integer",
+                  "format": "uuid"
+                }
+              }
+            }
+            """);
+
+        var loader = new YamlConfigLoader(_rootPath)
+            .RegisterTable<int, MonsterConfigStub>("monster", "monster", "schemas/monster.schema.json",
+                static config => config.Id);
+        var registry = new ConfigRegistry();
+
+        var exception = Assert.ThrowsAsync<ConfigLoadException>(async () => await loader.LoadAsync(registry));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception, Is.Not.Null);
+            Assert.That(exception!.Diagnostic.FailureKind, Is.EqualTo(ConfigLoadFailureKind.SchemaUnsupported));
+            Assert.That(exception.Diagnostic.DisplayPath, Is.EqualTo("hp"));
+            Assert.That(exception.Message, Does.Contain("only 'string' scalar types support string formats"));
+        });
+    }
+
+    /// <summary>
+    ///     验证 schema 将 <c>format</c> 声明为非字符串值时，会在 schema 解析阶段被拒绝。
+    /// </summary>
+    [Test]
+    public void LoadAsync_Should_Throw_When_Format_Is_Not_A_String()
+    {
+        CreateConfigFile(
+            "monster/slime.yaml",
+            """
+            id: 1
+            name: Slime
+            hp: 10
+            """);
+        CreateSchemaFile(
+            "schemas/monster.schema.json",
+            """
+            {
+              "type": "object",
+              "required": ["id", "name", "hp"],
+              "properties": {
+                "id": { "type": "integer" },
+                "name": {
+                  "type": "string",
+                  "format": 123
+                },
+                "hp": { "type": "integer" }
+              }
+            }
+            """);
+
+        var loader = new YamlConfigLoader(_rootPath)
+            .RegisterTable<int, MonsterConfigStub>("monster", "monster", "schemas/monster.schema.json",
+                static config => config.Id);
+        var registry = new ConfigRegistry();
+
+        var exception = Assert.ThrowsAsync<ConfigLoadException>(async () => await loader.LoadAsync(registry));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception, Is.Not.Null);
+            Assert.That(exception!.Diagnostic.FailureKind, Is.EqualTo(ConfigLoadFailureKind.SchemaUnsupported));
+            Assert.That(exception.Diagnostic.DisplayPath, Is.EqualTo("name"));
+            Assert.That(exception.Message, Does.Contain("must declare 'format' as a string"));
+        });
+    }
+
+    /// <summary>
     ///     验证运行时 schema 校验与 JS 工具对反向引用模式保持一致。
     /// </summary>
     [Test]

--- a/GFramework.Game/Config/YamlConfigSchemaValidator.cs
+++ b/GFramework.Game/Config/YamlConfigSchemaValidator.cs
@@ -10,7 +10,7 @@ namespace GFramework.Game.Config;
 ///     并通过递归遍历方式覆盖嵌套对象、对象数组、标量数组与深层 enum / 引用约束。
 ///     当前共享子集额外支持 <c>multipleOf</c>、<c>uniqueItems</c>、
 ///     <c>contains</c> / <c>minContains</c> / <c>maxContains</c>、
-///     <c>minProperties</c> 与 <c>maxProperties</c>，
+///     <c>minProperties</c>、<c>maxProperties</c> 与稳定字符串 <c>format</c> 子集，
 ///     让数值步进、数组去重、数组匹配计数和对象属性数量规则在运行时与生成器 / 工具侧保持一致。
 /// </summary>
 internal static class YamlConfigSchemaValidator
@@ -18,8 +18,21 @@ internal static class YamlConfigSchemaValidator
     // The runtime intentionally uses the same culture-invariant regex semantics as the
     // JS tooling so grouping and backreferences behave consistently across environments.
     private const RegexOptions SupportedPatternRegexOptions = RegexOptions.CultureInvariant;
+    private const string SupportedStringFormatNames = "'date', 'date-time', 'email', 'uri', 'uuid'";
     private static readonly Regex ExactDecimalPattern = new(
         @"^(?<sign>[+-]?)(?:(?<integer>\d+)(?:\.(?<fraction>\d*))?|\.(?<fractionOnly>\d+))(?:[eE](?<exponent>[+-]?\d+))?$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex SupportedEmailFormatRegex = new(
+        @"^[^@\s]+@[^@\s]+\.[^@\s]+$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex SupportedDateFormatRegex = new(
+        @"^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex SupportedDateTimeFormatRegex = new(
+        @"^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})(?<fraction>\.\d+)?(?<offset>Z|[+-]\d{2}:\d{2})$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex SupportedUriSchemeRegex = new(
+        @"^[A-Za-z][A-Za-z0-9+\.-]*:",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     /// <summary>
@@ -1120,11 +1133,11 @@ internal static class YamlConfigSchemaValidator
     }
 
     /// <summary>
-    ///     解析标量字段支持的范围、长度与模式约束。
-    ///     当前共享子集支持：
-    ///     `integer/number` 上的 `minimum/maximum/exclusiveMinimum/exclusiveMaximum`，
-    ///     以及 `string` 上的 `minLength/maxLength/pattern`。
-    /// </summary>
+///     解析标量字段支持的范围、长度与模式约束。
+///     当前共享子集支持：
+///     `integer/number` 上的 `minimum/maximum/exclusiveMinimum/exclusiveMaximum`，
+///     以及 `string` 上的 `minLength/maxLength/pattern/format`。
+/// </summary>
     /// <param name="tableName">所属配置表名称。</param>
     /// <param name="schemaPath">Schema 文件路径。</param>
     /// <param name="propertyPath">字段路径。</param>
@@ -1148,6 +1161,7 @@ internal static class YamlConfigSchemaValidator
         var minLength = TryParseLengthConstraint(tableName, schemaPath, propertyPath, element, nodeType, "minLength");
         var maxLength = TryParseLengthConstraint(tableName, schemaPath, propertyPath, element, nodeType, "maxLength");
         var pattern = TryParsePatternConstraint(tableName, schemaPath, propertyPath, element, nodeType);
+        var formatConstraint = TryParseFormatConstraint(tableName, schemaPath, propertyPath, element, nodeType);
 
         if (minimum.HasValue && maximum.HasValue && minimum.Value > maximum.Value)
         {
@@ -1187,7 +1201,8 @@ internal static class YamlConfigSchemaValidator
         var stringConstraints = CreateStringScalarConstraints(
             minLength,
             maxLength,
-            pattern);
+            pattern,
+            formatConstraint);
 
         return numericConstraints is null && stringConstraints is null
             ? null
@@ -1534,6 +1549,102 @@ internal static class YamlConfigSchemaValidator
     }
 
     /// <summary>
+    ///     读取字符串 format 约束。
+    ///     运行时只接受当前三端共享并已验证收益的稳定子集，避免把开放格式名误当成“全部支持”。
+    /// </summary>
+    /// <param name="tableName">所属配置表名称。</param>
+    /// <param name="schemaPath">Schema 文件路径。</param>
+    /// <param name="propertyPath">字段路径。</param>
+    /// <param name="element">Schema 节点。</param>
+    /// <param name="nodeType">字段类型。</param>
+    /// <returns>归一化后的 format 约束；未声明时返回空。</returns>
+    private static YamlConfigStringFormatConstraint? TryParseFormatConstraint(
+        string tableName,
+        string schemaPath,
+        string propertyPath,
+        JsonElement element,
+        YamlConfigSchemaPropertyType nodeType)
+    {
+        if (!element.TryGetProperty("format", out var formatElement))
+        {
+            return null;
+        }
+
+        if (nodeType != YamlConfigSchemaPropertyType.String)
+        {
+            throw ConfigLoadExceptionFactory.Create(
+                ConfigLoadFailureKind.SchemaUnsupported,
+                tableName,
+                $"Property '{propertyPath}' in schema file '{schemaPath}' uses 'format', but only 'string' scalar types support string formats.",
+                schemaPath: schemaPath,
+                displayPath: GetDiagnosticPath(propertyPath));
+        }
+
+        if (formatElement.ValueKind != JsonValueKind.String)
+        {
+            throw ConfigLoadExceptionFactory.Create(
+                ConfigLoadFailureKind.SchemaUnsupported,
+                tableName,
+                $"Property '{propertyPath}' in schema file '{schemaPath}' must declare 'format' as a string.",
+                schemaPath: schemaPath,
+                displayPath: GetDiagnosticPath(propertyPath));
+        }
+
+        var formatName = formatElement.GetString() ?? string.Empty;
+        if (TryMapSupportedStringFormat(formatName, out var kind))
+        {
+            return new YamlConfigStringFormatConstraint(formatName, kind);
+        }
+
+        throw ConfigLoadExceptionFactory.Create(
+            ConfigLoadFailureKind.SchemaUnsupported,
+            tableName,
+            $"Property '{propertyPath}' in schema file '{schemaPath}' declares unsupported string format '{formatName}'. Supported formats are {SupportedStringFormatNames}.",
+            schemaPath: schemaPath,
+            displayPath: GetDiagnosticPath(propertyPath),
+            rawValue: formatName);
+    }
+
+    /// <summary>
+    ///     将 schema 原文中的 format 名称映射为运行时共享枚举。
+    ///     映射阶段统一使用大小写敏感比较，避免同一 schema 在不同环境下被“宽松容错”解释成不同语义。
+    /// </summary>
+    /// <param name="formatName">schema 原始 format 名称。</param>
+    /// <param name="kind">解析成功时输出归一化枚举。</param>
+    /// <returns>当前格式是否属于共享支持子集。</returns>
+    private static bool TryMapSupportedStringFormat(
+        string formatName,
+        out YamlConfigStringFormatKind kind)
+    {
+        switch (formatName)
+        {
+            case "date":
+                kind = YamlConfigStringFormatKind.Date;
+                return true;
+
+            case "date-time":
+                kind = YamlConfigStringFormatKind.DateTime;
+                return true;
+
+            case "email":
+                kind = YamlConfigStringFormatKind.Email;
+                return true;
+
+            case "uri":
+                kind = YamlConfigStringFormatKind.Uri;
+                return true;
+
+            case "uuid":
+                kind = YamlConfigStringFormatKind.Uuid;
+                return true;
+
+            default:
+                kind = default;
+                return false;
+        }
+    }
+
+    /// <summary>
     ///     读取数组元素数量约束。
     /// </summary>
     /// <param name="tableName">所属配置表名称。</param>
@@ -1863,20 +1974,24 @@ internal static class YamlConfigSchemaValidator
 
     /// <summary>
     ///     根据已读取的字符串关键字创建字符串约束对象。
-    ///     正则会在 schema 解析阶段预编译，避免每次校验都重复实例化。
+    ///     正则会在 schema 解析阶段预编译，字符串 format 也会先归一化成共享枚举，
+    ///     避免每次校验都重新解释 schema 原文。
     /// </summary>
     /// <param name="minLength">最小长度约束。</param>
     /// <param name="maxLength">最大长度约束。</param>
     /// <param name="pattern">正则模式约束。</param>
+    /// <param name="formatConstraint">字符串 format 约束。</param>
     /// <returns>字符串约束对象；未声明任何字符串约束时返回空。</returns>
     private static YamlConfigStringConstraints? CreateStringScalarConstraints(
         int? minLength,
         int? maxLength,
-        string? pattern)
+        string? pattern,
+        YamlConfigStringFormatConstraint? formatConstraint)
     {
         return !minLength.HasValue &&
                !maxLength.HasValue &&
-               pattern is null
+               pattern is null &&
+               formatConstraint is null
             ? null
             : new YamlConfigStringConstraints(
                 minLength,
@@ -1886,7 +2001,8 @@ internal static class YamlConfigSchemaValidator
                     ? null
                     : new Regex(
                         pattern,
-                        SupportedPatternRegexOptions));
+                        SupportedPatternRegexOptions),
+                formatConstraint);
     }
 
     /// <summary>
@@ -2026,7 +2142,7 @@ internal static class YamlConfigSchemaValidator
     }
 
     /// <summary>
-    ///     校验字符串标量的长度与模式约束。
+    ///     校验字符串标量的长度、模式与 format 约束。
     /// </summary>
     /// <param name="tableName">所属配置表名称。</param>
     /// <param name="yamlPath">YAML 文件路径。</param>
@@ -2087,6 +2203,96 @@ internal static class YamlConfigSchemaValidator
                 rawValue: rawValue,
                 detail: $"Expected pattern: {constraints.Pattern}.");
         }
+
+        if (constraints.FormatConstraint is not null &&
+            !MatchesSupportedStringFormat(rawValue, constraints.FormatConstraint.Kind))
+        {
+            throw ConfigLoadExceptionFactory.Create(
+                ConfigLoadFailureKind.ConstraintViolation,
+                tableName,
+                $"Property '{displayPath}' in config file '{yamlPath}' must satisfy string format '{constraints.FormatConstraint.SchemaName}', but the current YAML scalar value is '{rawValue}'.",
+                yamlPath: yamlPath,
+                schemaPath: schemaNode.SchemaPathHint,
+                displayPath: GetDiagnosticPath(displayPath),
+                rawValue: rawValue,
+                detail: $"Expected string format: {constraints.FormatConstraint.SchemaName}.");
+        }
+    }
+
+    /// <summary>
+    ///     判断一个字符串是否满足当前共享支持的 format 子集。
+    ///     这里只接受 Runtime / Generator / Tooling 三端都能稳定解释的格式，
+    ///     避免把 JSON Schema 的开放格式名直接当成“全部支持”。
+    /// </summary>
+    /// <param name="value">待校验的字符串值。</param>
+    /// <param name="formatKind">共享 format 枚举。</param>
+    /// <returns>当前字符串是否满足指定 format。</returns>
+    private static bool MatchesSupportedStringFormat(
+        string value,
+        YamlConfigStringFormatKind formatKind)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        return formatKind switch
+        {
+            YamlConfigStringFormatKind.Date => MatchesSupportedDateFormat(value),
+            YamlConfigStringFormatKind.DateTime => MatchesSupportedDateTimeFormat(value),
+            YamlConfigStringFormatKind.Email => SupportedEmailFormatRegex.IsMatch(value),
+            YamlConfigStringFormatKind.Uri => MatchesSupportedUriFormat(value),
+            YamlConfigStringFormatKind.Uuid => Guid.TryParseExact(value, "D", out _),
+            _ => false
+        };
+    }
+
+    /// <summary>
+    ///     判断字符串是否满足共享支持的 <c>date</c> 格式。
+    ///     这里固定采用 <c>yyyy-MM-dd</c>，避免文化区域或宽松解析导致工具与运行时漂移。
+    /// </summary>
+    /// <param name="value">待校验的字符串值。</param>
+    /// <returns>当前值是否是合法日期。</returns>
+    private static bool MatchesSupportedDateFormat(string value)
+    {
+        return SupportedDateFormatRegex.IsMatch(value) &&
+               DateOnly.TryParseExact(
+                   value,
+                   "yyyy-MM-dd",
+                   CultureInfo.InvariantCulture,
+                   DateTimeStyles.None,
+                   out _);
+    }
+
+    /// <summary>
+    ///     判断字符串是否满足共享支持的 <c>date-time</c> 格式。
+    ///     该格式固定要求显式时区偏移，避免消费者误把本地时区文本当成跨进程稳定配置。
+    /// </summary>
+    /// <param name="value">待校验的字符串值。</param>
+    /// <returns>当前值是否是合法时间戳。</returns>
+    private static bool MatchesSupportedDateTimeFormat(string value)
+    {
+        if (!SupportedDateTimeFormatRegex.IsMatch(value))
+        {
+            return false;
+        }
+
+        return DateTimeOffset.TryParseExact(
+            value,
+            ["yyyy'-'MM'-'dd'T'HH':'mm':'ssK", "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK"],
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out _);
+    }
+
+    /// <summary>
+    ///     判断字符串是否满足共享支持的 <c>uri</c> 格式。
+    ///     这里要求输入显式包含 scheme，避免把普通路径意外解释成平台相关的绝对 URI。
+    /// </summary>
+    /// <param name="value">待校验的字符串值。</param>
+    /// <returns>当前值是否是合法绝对 URI。</returns>
+    private static bool MatchesSupportedUriFormat(string value)
+    {
+        return SupportedUriSchemeRegex.IsMatch(value) &&
+               Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
+               uri.IsAbsoluteUri;
     }
 
     /// <summary>
@@ -3321,28 +3527,32 @@ internal sealed class YamlConfigNumericConstraints
 }
 
 /// <summary>
-///     表示标量节点上声明的字符串长度与模式约束。
-///     该模型将正则原文与预编译正则绑定保存，保证诊断内容与运行时匹配逻辑保持一致。
+///     表示标量节点上声明的字符串长度、模式与 format 约束。
+///     该模型将正则原文、预编译正则和共享 format 枚举绑定保存，
+///     保证诊断内容与运行时匹配逻辑保持一致。
 /// </summary>
 internal sealed class YamlConfigStringConstraints
 {
     /// <summary>
-    ///     初始化字符串约束模型。
-    /// </summary>
+///     初始化字符串约束模型。
+/// </summary>
     /// <param name="minLength">最小长度约束。</param>
     /// <param name="maxLength">最大长度约束。</param>
     /// <param name="pattern">正则模式约束原文。</param>
     /// <param name="patternRegex">已编译的正则表达式。</param>
+    /// <param name="formatConstraint">字符串 format 约束。</param>
     public YamlConfigStringConstraints(
         int? minLength,
         int? maxLength,
         string? pattern,
-        Regex? patternRegex)
+        Regex? patternRegex,
+        YamlConfigStringFormatConstraint? formatConstraint)
     {
         MinLength = minLength;
         MaxLength = maxLength;
         Pattern = pattern;
         PatternRegex = patternRegex;
+        FormatConstraint = formatConstraint;
     }
 
     /// <summary>
@@ -3364,6 +3574,74 @@ internal sealed class YamlConfigStringConstraints
     ///     获取已编译的正则表达式。
     /// </summary>
     public Regex? PatternRegex { get; }
+
+    /// <summary>
+    ///     获取字符串 format 约束。
+    /// </summary>
+    public YamlConfigStringFormatConstraint? FormatConstraint { get; }
+}
+
+/// <summary>
+///     表示一个已归一化的字符串 format 约束。
+///     该模型同时保留 schema 原文与共享枚举，方便诊断信息稳定展示，又避免运行时校验反复解析字符串。
+/// </summary>
+internal sealed class YamlConfigStringFormatConstraint
+{
+    /// <summary>
+    ///     初始化字符串 format 约束模型。
+    /// </summary>
+    /// <param name="schemaName">schema 中声明的 format 名称。</param>
+    /// <param name="kind">归一化后的共享 format 枚举。</param>
+    public YamlConfigStringFormatConstraint(
+        string schemaName,
+        YamlConfigStringFormatKind kind)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaName);
+
+        SchemaName = schemaName;
+        Kind = kind;
+    }
+
+    /// <summary>
+    ///     获取 schema 中声明的 format 名称。
+    /// </summary>
+    public string SchemaName { get; }
+
+    /// <summary>
+    ///     获取归一化后的共享 format 枚举。
+    /// </summary>
+    public YamlConfigStringFormatKind Kind { get; }
+}
+
+/// <summary>
+///     表示当前 Runtime / Generator / Tooling 共享支持的字符串 format 子集。
+/// </summary>
+internal enum YamlConfigStringFormatKind
+{
+    /// <summary>
+    ///     表示 <c>yyyy-MM-dd</c> 形式的日期。
+    /// </summary>
+    Date,
+
+    /// <summary>
+    ///     表示带显式时区偏移的 RFC 3339 日期时间。
+    /// </summary>
+    DateTime,
+
+    /// <summary>
+    ///     表示基础电子邮件地址格式。
+    /// </summary>
+    Email,
+
+    /// <summary>
+    ///     表示绝对 URI。
+    /// </summary>
+    Uri,
+
+    /// <summary>
+    ///     表示连字符分隔的 UUID 文本。
+    /// </summary>
+    Uuid
 }
 
 /// <summary>

--- a/GFramework.SourceGenerators.Tests/Config/SchemaConfigGeneratorTests.cs
+++ b/GFramework.SourceGenerators.Tests/Config/SchemaConfigGeneratorTests.cs
@@ -182,6 +182,95 @@ public class SchemaConfigGeneratorTests
     }
 
     /// <summary>
+    ///     验证根节点在非字符串 schema 上声明 <c>format</c> 时也会在生成阶段直接给出诊断。
+    /// </summary>
+    [Test]
+    public void Run_Should_Report_Diagnostic_When_Root_Node_Uses_Format()
+    {
+        const string source = """
+                              namespace TestApp
+                              {
+                                  public sealed class Dummy
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string schema = """
+                              {
+                                "type": "object",
+                                "format": "uuid",
+                                "required": ["id"],
+                                "properties": {
+                                  "id": { "type": "integer" }
+                                }
+                              }
+                              """;
+
+        var result = SchemaGeneratorTestDriver.Run(
+            source,
+            ("monster.schema.json", schema));
+
+        var diagnostic = result.Results.Single().Diagnostics.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(diagnostic.Id, Is.EqualTo("GF_ConfigSchema_009"));
+            Assert.That(diagnostic.Severity, Is.EqualTo(DiagnosticSeverity.Error));
+            Assert.That(diagnostic.GetMessage(), Does.Contain("<root>"));
+            Assert.That(diagnostic.GetMessage(), Does.Contain("Only 'string' properties can declare 'format'."));
+        });
+    }
+
+    /// <summary>
+    ///     验证数组 <c>contains</c> 子 schema 内的非法 <c>format</c> 也会在生成阶段直接给出诊断。
+    /// </summary>
+    [Test]
+    public void Run_Should_Report_Diagnostic_When_Contains_Schema_Uses_Format_On_Non_String_Node()
+    {
+        const string source = """
+                              namespace TestApp
+                              {
+                                  public sealed class Dummy
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string schema = """
+                              {
+                                "type": "object",
+                                "required": ["id", "dropIds"],
+                                "properties": {
+                                  "id": { "type": "integer" },
+                                  "dropIds": {
+                                    "type": "array",
+                                    "items": { "type": "integer" },
+                                    "contains": {
+                                      "type": "integer",
+                                      "format": "uuid"
+                                    }
+                                  }
+                                }
+                              }
+                              """;
+
+        var result = SchemaGeneratorTestDriver.Run(
+            source,
+            ("monster.schema.json", schema));
+
+        var diagnostic = result.Results.Single().Diagnostics.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(diagnostic.Id, Is.EqualTo("GF_ConfigSchema_009"));
+            Assert.That(diagnostic.Severity, Is.EqualTo(DiagnosticSeverity.Error));
+            Assert.That(diagnostic.GetMessage(), Does.Contain("dropIds[contains]"));
+            Assert.That(diagnostic.GetMessage(), Does.Contain("Only 'string' properties can declare 'format'."));
+        });
+    }
+
+    /// <summary>
     ///     验证深层不支持的数组嵌套会带着完整字段路径产生命名明确的诊断。
     /// </summary>
     [Test]

--- a/GFramework.SourceGenerators.Tests/Config/SchemaConfigGeneratorTests.cs
+++ b/GFramework.SourceGenerators.Tests/Config/SchemaConfigGeneratorTests.cs
@@ -92,6 +92,96 @@ public class SchemaConfigGeneratorTests
     }
 
     /// <summary>
+    ///     验证共享支持的字符串 <c>format</c> 会写入生成 XML 文档。
+    /// </summary>
+    [Test]
+    public void Run_Should_Write_Supported_String_Format_Into_Generated_Documentation()
+    {
+        const string source = """
+                              namespace TestApp
+                              {
+                                  public sealed class Dummy
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string schema = """
+                              {
+                                "type": "object",
+                                "required": ["id", "contactEmail"],
+                                "properties": {
+                                  "id": { "type": "integer" },
+                                  "contactEmail": {
+                                    "type": "string",
+                                    "format": "email"
+                                  }
+                                }
+                              }
+                              """;
+
+        var result = SchemaGeneratorTestDriver.Run(
+            source,
+            ("monster.schema.json", schema));
+
+        var generatedSources = result.Results
+            .Single()
+            .GeneratedSources
+            .ToDictionary(
+                static sourceResult => sourceResult.HintName,
+                static sourceResult => sourceResult.SourceText.ToString(),
+                StringComparer.Ordinal);
+
+        Assert.That(result.Results.Single().Diagnostics, Is.Empty);
+        Assert.That(generatedSources["MonsterConfig.g.cs"], Does.Contain("Constraints: format = 'email'."));
+    }
+
+    /// <summary>
+    ///     验证未纳入共享子集的字符串 <c>format</c> 会在生成阶段直接给出诊断。
+    /// </summary>
+    [Test]
+    public void Run_Should_Report_Diagnostic_When_String_Format_Is_Not_Supported()
+    {
+        const string source = """
+                              namespace TestApp
+                              {
+                                  public sealed class Dummy
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string schema = """
+                              {
+                                "type": "object",
+                                "required": ["id", "address"],
+                                "properties": {
+                                  "id": { "type": "integer" },
+                                  "address": {
+                                    "type": "string",
+                                    "format": "ipv4"
+                                  }
+                                }
+                              }
+                              """;
+
+        var result = SchemaGeneratorTestDriver.Run(
+            source,
+            ("monster.schema.json", schema));
+
+        var diagnostic = result.Results.Single().Diagnostics.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(diagnostic.Id, Is.EqualTo("GF_ConfigSchema_009"));
+            Assert.That(diagnostic.Severity, Is.EqualTo(DiagnosticSeverity.Error));
+            Assert.That(diagnostic.GetMessage(), Does.Contain("address"));
+            Assert.That(diagnostic.GetMessage(), Does.Contain("ipv4"));
+            Assert.That(diagnostic.GetMessage(), Does.Contain("date-time"));
+        });
+    }
+
+    /// <summary>
     ///     验证深层不支持的数组嵌套会带着完整字段路径产生命名明确的诊断。
     /// </summary>
     [Test]

--- a/GFramework.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/GFramework.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -26,6 +26,7 @@
  GF_ConfigSchema_006        | GFramework.SourceGenerators.Config | Error    | ConfigSchemaDiagnostics        
  GF_ConfigSchema_007        | GFramework.SourceGenerators.Config | Error    | ConfigSchemaDiagnostics        
  GF_ConfigSchema_008        | GFramework.SourceGenerators.Config | Error    | ConfigSchemaDiagnostics        
+ GF_ConfigSchema_009        | GFramework.SourceGenerators.Config | Error    | ConfigSchemaDiagnostics        
  GF_Priority_001            | GFramework.Priority                | Error    | PriorityDiagnostic             
  GF_Priority_002            | GFramework.Priority                | Warning  | PriorityDiagnostic             
  GF_Priority_003            | GFramework.Priority                | Error    | PriorityDiagnostic             

--- a/GFramework.SourceGenerators/Config/SchemaConfigGenerator.cs
+++ b/GFramework.SourceGenerators/Config/SchemaConfigGenerator.cs
@@ -126,6 +126,15 @@ public sealed class SchemaConfigGenerator : IIncrementalGenerator
                         Path.GetFileName(file.Path)));
             }
 
+            if (!TryValidateStringFormatMetadataRecursively(
+                    file.Path,
+                    "<root>",
+                    root,
+                    out var rootFormatDiagnostic))
+            {
+                return SchemaParseResult.FromDiagnostic(rootFormatDiagnostic!);
+            }
+
             var entityName = ToPascalCase(GetSchemaBaseName(file.Path));
             var rootObject = ParseObjectSpec(
                 file.Path,
@@ -602,6 +611,83 @@ public sealed class SchemaConfigGenerator : IIncrementalGenerator
             displayPath,
             $"Unsupported string format '{formatName}'. Supported formats are {SupportedStringFormatNames}.");
         return false;
+    }
+
+    /// <summary>
+    ///     递归验证 schema 树中的字符串 <c>format</c> 元数据。
+    ///     该遍历专门补足根节点、<c>contains</c> 子 schema 等不会完全进入常规属性解析路径的片段，
+    ///     避免生成器对同一份 schema 比运行时和工具链更宽松。
+    /// </summary>
+    /// <param name="filePath">Schema 文件路径。</param>
+    /// <param name="displayPath">逻辑字段路径。</param>
+    /// <param name="element">当前 schema 节点。</param>
+    /// <param name="diagnostic">失败时返回的诊断。</param>
+    /// <returns>当前节点树的 format 元数据是否有效。</returns>
+    private static bool TryValidateStringFormatMetadataRecursively(
+        string filePath,
+        string displayPath,
+        JsonElement element,
+        out Diagnostic? diagnostic)
+    {
+        diagnostic = null;
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return true;
+        }
+
+        var schemaType = string.Empty;
+        if (element.TryGetProperty("type", out var typeElement) &&
+            typeElement.ValueKind == JsonValueKind.String)
+        {
+            schemaType = typeElement.GetString() ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(schemaType) &&
+                !TryValidateStringFormatMetadata(filePath, displayPath, element, schemaType, out diagnostic))
+            {
+                return false;
+            }
+        }
+
+        if (string.Equals(schemaType, "object", StringComparison.Ordinal) &&
+            element.TryGetProperty("properties", out var propertiesElement) &&
+            propertiesElement.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in propertiesElement.EnumerateObject())
+            {
+                if (!TryValidateStringFormatMetadataRecursively(
+                        filePath,
+                        CombinePath(displayPath, property.Name),
+                        property.Value,
+                        out diagnostic))
+                {
+                    return false;
+                }
+            }
+        }
+
+        if (!string.Equals(schemaType, "array", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (element.TryGetProperty("items", out var itemsElement) &&
+            itemsElement.ValueKind == JsonValueKind.Object &&
+            !TryValidateStringFormatMetadataRecursively(filePath, $"{displayPath}[]", itemsElement, out diagnostic))
+        {
+            return false;
+        }
+
+        if (element.TryGetProperty("contains", out var containsElement) &&
+            containsElement.ValueKind == JsonValueKind.Object &&
+            !TryValidateStringFormatMetadataRecursively(
+                filePath,
+                $"{displayPath}[contains]",
+                containsElement,
+                out diagnostic))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/GFramework.SourceGenerators/Config/SchemaConfigGenerator.cs
+++ b/GFramework.SourceGenerators/Config/SchemaConfigGenerator.cs
@@ -8,7 +8,7 @@ namespace GFramework.SourceGenerators.Config;
 ///     支持嵌套对象、对象数组、标量数组，以及可映射的 default / enum / const / ref-table 元数据。
 ///     当前共享子集也会把 <c>multipleOf</c>、<c>uniqueItems</c>、
 ///     <c>contains</c> / <c>minContains</c> / <c>maxContains</c>、
-///     <c>minProperties</c> 与 <c>maxProperties</c> 写入生成代码文档，
+///     <c>minProperties</c>、<c>maxProperties</c> 与稳定字符串 <c>format</c> 子集写入生成代码文档，
 ///     让消费者能直接在强类型 API 上看到运行时生效的约束。
 /// </summary>
 [Generator]
@@ -25,6 +25,7 @@ public sealed class SchemaConfigGenerator : IIncrementalGenerator
         "The primary key already has Get/TryGet lookup semantics and should not declare a generated lookup index.";
     private const string LookupIndexReferencePropertyMessage =
         "Reference properties are excluded from generated lookup indexes because they already carry cross-table semantics.";
+    private const string SupportedStringFormatNames = "'date', 'date-time', 'email', 'uri', and 'uuid'";
 
     /// <inheritdoc />
     public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -295,6 +296,16 @@ public sealed class SchemaConfigGenerator : IIncrementalGenerator
         var title = TryGetMetadataString(property.Value, "title");
         var description = TryGetMetadataString(property.Value, "description");
         var refTableName = TryGetMetadataString(property.Value, "x-gframework-ref-table");
+        if (!TryValidateStringFormatMetadata(
+                filePath,
+                displayPath,
+                property.Value,
+                schemaType,
+                out var formatDiagnostic))
+        {
+            return ParsedPropertyResult.FromDiagnostic(formatDiagnostic!);
+        }
+
         var indexedLookupMetadata = TryGetMetadataBoolean(property.Value, LookupIndexMetadataKey);
         if (indexedLookupMetadata.Diagnostic is not null)
         {
@@ -534,6 +545,84 @@ public sealed class SchemaConfigGenerator : IIncrementalGenerator
     }
 
     /// <summary>
+    ///     验证字符串 <c>format</c> 元数据是否属于当前共享支持子集。
+    ///     生成器不尝试解释开放格式名，而是直接在编译阶段拒绝三端无法稳定对齐的 schema。
+    /// </summary>
+    /// <param name="filePath">Schema 文件路径。</param>
+    /// <param name="displayPath">逻辑字段路径。</param>
+    /// <param name="element">属性 schema 节点。</param>
+    /// <param name="schemaType">当前 schema type。</param>
+    /// <param name="diagnostic">失败时返回的诊断。</param>
+    /// <returns>当前节点的 format 元数据是否有效。</returns>
+    private static bool TryValidateStringFormatMetadata(
+        string filePath,
+        string displayPath,
+        JsonElement element,
+        string schemaType,
+        out Diagnostic? diagnostic)
+    {
+        diagnostic = null;
+        if (!element.TryGetProperty("format", out var formatElement))
+        {
+            return true;
+        }
+
+        if (!string.Equals(schemaType, "string", StringComparison.Ordinal))
+        {
+            diagnostic = Diagnostic.Create(
+                ConfigSchemaDiagnostics.InvalidStringFormatMetadata,
+                CreateFileLocation(filePath),
+                Path.GetFileName(filePath),
+                displayPath,
+                "Only 'string' properties can declare 'format'.");
+            return false;
+        }
+
+        if (formatElement.ValueKind != JsonValueKind.String)
+        {
+            diagnostic = Diagnostic.Create(
+                ConfigSchemaDiagnostics.InvalidStringFormatMetadata,
+                CreateFileLocation(filePath),
+                Path.GetFileName(filePath),
+                displayPath,
+                "The 'format' value must be a string.");
+            return false;
+        }
+
+        var formatName = formatElement.GetString() ?? string.Empty;
+        if (IsSupportedStringFormat(formatName))
+        {
+            return true;
+        }
+
+        diagnostic = Diagnostic.Create(
+            ConfigSchemaDiagnostics.InvalidStringFormatMetadata,
+            CreateFileLocation(filePath),
+            Path.GetFileName(filePath),
+            displayPath,
+            $"Unsupported string format '{formatName}'. Supported formats are {SupportedStringFormatNames}.");
+        return false;
+    }
+
+    /// <summary>
+    ///     判断给定 format 名称是否属于当前共享支持子集。
+    /// </summary>
+    /// <param name="formatName">schema 中声明的 format 名称。</param>
+    /// <returns>是否支持该格式。</returns>
+    private static bool IsSupportedStringFormat(string formatName)
+    {
+        return formatName switch
+        {
+            "date" => true,
+            "date-time" => true,
+            "email" => true,
+            "uri" => true,
+            "uuid" => true,
+            _ => false
+        };
+    }
+
+    /// <summary>
     ///     解析数组属性，支持标量数组与对象数组。
     /// </summary>
     /// <param name="filePath">Schema 文件路径。</param>
@@ -577,6 +666,11 @@ public sealed class SchemaConfigGenerator : IIncrementalGenerator
         }
 
         var itemType = itemTypeElement.GetString() ?? string.Empty;
+        if (!TryValidateStringFormatMetadata(filePath, $"{displayPath}[]", itemsElement, itemType, out var formatDiagnostic))
+        {
+            return ParsedPropertyResult.FromDiagnostic(formatDiagnostic!);
+        }
+
         switch (itemType)
         {
             case "integer":
@@ -2506,6 +2600,17 @@ public sealed class SchemaConfigGenerator : IIncrementalGenerator
             patternElement.ValueKind == JsonValueKind.String)
         {
             parts.Add($"pattern = '{patternElement.GetString() ?? string.Empty}'");
+        }
+
+        if (schemaType == "string" &&
+            element.TryGetProperty("format", out var formatElement) &&
+            formatElement.ValueKind == JsonValueKind.String)
+        {
+            var formatName = formatElement.GetString() ?? string.Empty;
+            if (IsSupportedStringFormat(formatName))
+            {
+                parts.Add($"format = '{formatName}'");
+            }
         }
 
         if (schemaType == "array" &&

--- a/GFramework.SourceGenerators/Diagnostics/ConfigSchemaDiagnostics.cs
+++ b/GFramework.SourceGenerators/Diagnostics/ConfigSchemaDiagnostics.cs
@@ -96,4 +96,15 @@ public static class ConfigSchemaDiagnostics
         SourceGeneratorsConfigCategory,
         DiagnosticSeverity.Error,
         true);
+
+    /// <summary>
+    ///     schema 字段的字符串 format 元数据无效。
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidStringFormatMetadata = new(
+        "GF_ConfigSchema_009",
+        "Config schema uses invalid string format metadata",
+        "Property '{1}' in schema file '{0}' uses invalid 'format' metadata: {2}",
+        SourceGeneratorsConfigCategory,
+        DiagnosticSeverity.Error,
+        true);
 }

--- a/docs/zh-CN/game/config-system.md
+++ b/docs/zh-CN/game/config-system.md
@@ -874,7 +874,7 @@ var hotReload = loader.EnableHotReload(
 - 对带 `x-gframework-ref-table` 的字段提供引用 schema / 配置域 / 引用文件跳转入口
 - 对空配置文件提供基于 schema 的示例 YAML 初始化入口
 - 对同一配置域内的多份 YAML 文件执行批量字段更新
-- 在表单入口中显示 `title / description / default / const / enum / ref-table / multipleOf / pattern / format / uniqueItems / contains / minContains / maxContains / minProperties / maxProperties` 元数据；批量编辑入口当前只暴露顶层可批量改写字段所需的基础信息
+- 在表单入口中显示 `title / description / default / const / enum / x-gframework-ref-table（UI 中显示为 ref-table） / multipleOf / pattern / format / uniqueItems / contains / minContains / maxContains / minProperties / maxProperties` 元数据；批量编辑入口当前只暴露顶层可批量改写字段所需的基础信息
 
 当前表单入口适合编辑嵌套对象中的标量字段、标量数组，以及对象数组中的对象项。
 

--- a/docs/zh-CN/game/config-system.md
+++ b/docs/zh-CN/game/config-system.md
@@ -12,7 +12,7 @@
 - JSON Schema 作为结构描述
 - 一对象一文件的目录组织
 - 运行时只读查询
-- Runtime / Generator / Tooling 共享支持 `const`、`minimum`、`maximum`、`exclusiveMinimum`、`exclusiveMaximum`、`multipleOf`、`minLength`、`maxLength`、`pattern`、`minItems`、`maxItems`、`uniqueItems`、`contains`、`minContains`、`maxContains`、`minProperties`、`maxProperties`
+- Runtime / Generator / Tooling 共享支持 `const`、`minimum`、`maximum`、`exclusiveMinimum`、`exclusiveMaximum`、`multipleOf`、`minLength`、`maxLength`、`pattern`、`format`（当前稳定子集：`date`、`date-time`、`email`、`uri`、`uuid`）、`minItems`、`maxItems`、`uniqueItems`、`contains`、`minContains`、`maxContains`、`minProperties`、`maxProperties`
 - Source Generator 生成配置类型、表包装、单表注册/访问辅助，以及项目级聚合注册目录
 - VS Code 插件提供配置浏览、raw 编辑、schema 打开、递归轻量校验和嵌套对象表单入口
 
@@ -714,6 +714,7 @@ var loader = new YamlConfigLoader("config-root")
 - 数值字段违反 `multipleOf`
 - 字符串字段违反 `minLength` / `maxLength`
 - 字符串字段违反 `pattern`
+- 字符串字段违反 `format`
 - 数组字段违反 `minItems` / `maxItems`
 - 数组字段违反 `uniqueItems`
 - 数组字段违反 `contains` / `minContains` / `maxContains`
@@ -772,6 +773,7 @@ if (MonsterConfigBindings.References.TryGetByDisplayPath("dropItems", out var re
 - `multipleOf`：供运行时校验、VS Code 校验、表单 hint 和生成代码 XML 文档复用；当前优先按运行时与 JS 共用的十进制精确整倍数判定处理常见十进制步进，并在必要时退回浮点容差兜底
 - `minLength` / `maxLength`：供运行时校验、VS Code 校验和生成代码 XML 文档复用
 - `pattern`：供运行时校验、VS Code 校验、表单提示和生成代码 XML 文档复用；当前按 C# `CultureInvariant` 与 JS Unicode `u` 模式解释，非法模式会在 schema 解析阶段直接报错
+- `format`：当前只支持 Runtime / Generator / Tooling 三端都能稳定对齐的字符串子集 `date`、`date-time`、`email`、`uri`、`uuid`；运行时会拒绝不满足格式的值，VS Code 校验与表单 hint 会同步展示该约束，生成代码 XML 文档也会保留 `format = ...` 说明
 - `minItems` / `maxItems`：供运行时校验、VS Code 校验、表单提示和生成代码 XML 文档复用
 - `uniqueItems`：供运行时校验、VS Code 校验、表单 hint 和生成代码 XML 文档复用；对象数组会按 schema 归一化后的结构比较重复项，而不是依赖 YAML 字段顺序
 - `contains` / `minContains` / `maxContains`：供运行时校验、VS Code 校验、表单 hint 和生成代码 XML 文档复用；当前会按同一套递归 schema 规则统计“有多少数组元素匹配 contains 子 schema”，其中仅声明 `contains` 时默认至少需要 1 个匹配元素
@@ -872,7 +874,7 @@ var hotReload = loader.EnableHotReload(
 - 对带 `x-gframework-ref-table` 的字段提供引用 schema / 配置域 / 引用文件跳转入口
 - 对空配置文件提供基于 schema 的示例 YAML 初始化入口
 - 对同一配置域内的多份 YAML 文件执行批量字段更新
-- 在表单入口中显示 `title / description / default / const / enum / ref-table / multipleOf / uniqueItems / contains / minContains / maxContains / minProperties / maxProperties` 元数据；批量编辑入口当前只暴露顶层可批量改写字段所需的基础信息
+- 在表单入口中显示 `title / description / default / const / enum / ref-table / multipleOf / pattern / format / uniqueItems / contains / minContains / maxContains / minProperties / maxProperties` 元数据；批量编辑入口当前只暴露顶层可批量改写字段所需的基础信息
 
 当前表单入口适合编辑嵌套对象中的标量字段、标量数组，以及对象数组中的对象项。
 

--- a/tools/gframework-config-tool/src/configValidation.js
+++ b/tools/gframework-config-tool/src/configValidation.js
@@ -719,11 +719,13 @@ function isValidCalendarDate(year, month, day) {
         return false;
     }
 
-    if (month < 1 || month > 12 || day < 1) {
+    if (year < 1 || year > 9999 || month < 1 || month > 12 || day < 1) {
         return false;
     }
 
-    const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+    const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0);
+    const monthDays = [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    const lastDay = monthDays[month - 1];
     return day <= lastDay;
 }
 

--- a/tools/gframework-config-tool/src/configValidation.js
+++ b/tools/gframework-config-tool/src/configValidation.js
@@ -464,12 +464,12 @@ function normalizeSchemaPattern(value, displayPath) {
  * @returns {string | undefined} Normalized format name.
  */
 function normalizeSchemaStringFormat(value, schemaType, displayPath) {
-    if (schemaType !== "string") {
+    if (value === undefined) {
         return undefined;
     }
 
-    if (value === undefined) {
-        return undefined;
+    if (schemaType !== "string") {
+        throw new Error(`Schema property '${displayPath}' can only declare 'format' on type 'string'.`);
     }
 
     if (typeof value !== "string") {

--- a/tools/gframework-config-tool/src/configValidation.js
+++ b/tools/gframework-config-tool/src/configValidation.js
@@ -9,6 +9,12 @@ const {ValidationMessageKeys} = require("./localizationKeys");
 const IntegerScalarPattern = /^[+-]?\d+$/u;
 const NumberScalarPattern = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/u;
 const BooleanScalarPattern = /^(true|false)$/iu;
+const EmailFormatPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u;
+const UuidFormatPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+const DateFormatPattern = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/u;
+const DateTimeFormatPattern =
+    /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})(?<fraction>\.\d+)?(?<offset>Z|[+-]\d{2}:\d{2})$/u;
+const SupportedStringFormats = new Set(["date", "date-time", "email", "uri", "uuid"]);
 
 /**
  * Compare two strings using the same UTF-16 code-unit ordering as C#'s
@@ -32,7 +38,7 @@ function compareStringsOrdinal(left, right) {
  * runtime validator and source generator so tooling diagnostics stay aligned.
  *
  * @param {string} content Raw schema JSON text.
- * @throws {Error} Thrown when the schema declares one unsupported or invalid pattern string.
+ * @throws {Error} Thrown when the schema declares one unsupported pattern or format string.
  * @returns {{
  *   type: "object",
  *   required: string[],
@@ -447,6 +453,39 @@ function normalizeSchemaPattern(value, displayPath) {
 }
 
 /**
+ * Normalize one schema string-format declaration into the shared supported subset.
+ * The tooling intentionally rejects unknown format names so editor diagnostics do
+ * not drift away from the runtime and source generator.
+ *
+ * @param {unknown} value Raw schema value.
+ * @param {string} schemaType Current schema type.
+ * @param {string} displayPath Logical property path used in diagnostics.
+ * @throws {Error} Thrown when the format value is invalid or unsupported for strings.
+ * @returns {string | undefined} Normalized format name.
+ */
+function normalizeSchemaStringFormat(value, schemaType, displayPath) {
+    if (schemaType !== "string") {
+        return undefined;
+    }
+
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (typeof value !== "string") {
+        throw new Error(`Schema property '${displayPath}' must declare 'format' as a string.`);
+    }
+
+    if (SupportedStringFormats.has(value)) {
+        return value;
+    }
+
+    throw new Error(
+        `Schema property '${displayPath}' declares unsupported string format '${value}'. ` +
+        "Supported formats are 'date', 'date-time', 'email', 'uri', and 'uuid'.");
+}
+
+/**
  * Convert a schema default value into a compact string that can be shown in UI
  * metadata hints.
  *
@@ -568,6 +607,124 @@ function matchesSchemaPattern(scalarValue, patternRegex) {
     }
 
     return patternRegex.test(scalarValue);
+}
+
+/**
+ * Test one scalar value against one shared string-format constraint.
+ *
+ * @param {string} scalarValue Scalar value from YAML.
+ * @param {string | undefined} formatName Normalized schema format name.
+ * @returns {boolean} True when compatible or no format is declared.
+ */
+function matchesSchemaStringFormat(scalarValue, formatName) {
+    if (typeof formatName !== "string") {
+        return true;
+    }
+
+    switch (formatName) {
+        case "date":
+            return matchesSchemaDateFormat(scalarValue);
+        case "date-time":
+            return matchesSchemaDateTimeFormat(scalarValue);
+        case "email":
+            return EmailFormatPattern.test(scalarValue);
+        case "uri":
+            return matchesSchemaUriFormat(scalarValue);
+        case "uuid":
+            return UuidFormatPattern.test(scalarValue);
+        default:
+            return false;
+    }
+}
+
+/**
+ * Validate one RFC 3339 full-date string.
+ *
+ * @param {string} scalarValue Scalar value from YAML.
+ * @returns {boolean} True when the value is a valid calendar date.
+ */
+function matchesSchemaDateFormat(scalarValue) {
+    const match = DateFormatPattern.exec(scalarValue);
+    if (!match || !match.groups) {
+        return false;
+    }
+
+    const year = Number.parseInt(match.groups.year, 10);
+    const month = Number.parseInt(match.groups.month, 10);
+    const day = Number.parseInt(match.groups.day, 10);
+    return isValidCalendarDate(year, month, day);
+}
+
+/**
+ * Validate one RFC 3339 date-time string with explicit timezone offset.
+ *
+ * @param {string} scalarValue Scalar value from YAML.
+ * @returns {boolean} True when the value is structurally and calendrically valid.
+ */
+function matchesSchemaDateTimeFormat(scalarValue) {
+    const match = DateTimeFormatPattern.exec(scalarValue);
+    if (!match || !match.groups) {
+        return false;
+    }
+
+    const year = Number.parseInt(match.groups.year, 10);
+    const month = Number.parseInt(match.groups.month, 10);
+    const day = Number.parseInt(match.groups.day, 10);
+    if (!isValidCalendarDate(year, month, day)) {
+        return false;
+    }
+
+    const hour = Number.parseInt(match.groups.hour, 10);
+    const minute = Number.parseInt(match.groups.minute, 10);
+    const second = Number.parseInt(match.groups.second, 10);
+    if (hour > 23 || minute > 59 || second > 59) {
+        return false;
+    }
+
+    const offset = match.groups.offset;
+    if (offset === "Z") {
+        return true;
+    }
+
+    const offsetHour = Number.parseInt(offset.slice(1, 3), 10);
+    const offsetMinute = Number.parseInt(offset.slice(4, 6), 10);
+    return offsetHour <= 23 && offsetMinute <= 59;
+}
+
+/**
+ * Validate one absolute URI string using the platform URL parser.
+ *
+ * @param {string} scalarValue Scalar value from YAML.
+ * @returns {boolean} True when the value parses as an absolute URI.
+ */
+function matchesSchemaUriFormat(scalarValue) {
+    try {
+        const parsed = new URL(scalarValue);
+        return typeof parsed.protocol === "string" && parsed.protocol.length > 1;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Check whether one year-month-day triple forms a valid calendar date.
+ *
+ * @param {number} year Year component.
+ * @param {number} month Month component.
+ * @param {number} day Day component.
+ * @returns {boolean} True when the date exists in the Gregorian calendar.
+ */
+function isValidCalendarDate(year, month, day) {
+    if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+        return false;
+    }
+
+    if (month < 1 || month > 12 || day < 1) {
+        return false;
+    }
+
+    const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+    return day <= lastDay;
 }
 
 /**
@@ -845,6 +1002,7 @@ function parseSchemaNode(rawNode, displayPath) {
     const value = rawNode && typeof rawNode === "object" ? rawNode : {};
     const type = typeof value.type === "string" ? value.type : "object";
     const patternMetadata = normalizeSchemaPattern(value.pattern, displayPath);
+    const stringFormat = normalizeSchemaStringFormat(value.format, type, displayPath);
     const metadata = {
         title: typeof value.title === "string" ? value.title : undefined,
         description: typeof value.description === "string" ? value.description : undefined,
@@ -858,6 +1016,7 @@ function parseSchemaNode(rawNode, displayPath) {
         maxLength: normalizeSchemaNonNegativeInteger(value.maxLength),
         pattern: patternMetadata ? patternMetadata.source : undefined,
         patternRegex: patternMetadata ? patternMetadata.regex : undefined,
+        format: stringFormat,
         minItems: normalizeSchemaNonNegativeInteger(value.minItems),
         maxItems: normalizeSchemaNonNegativeInteger(value.maxItems),
         minContains: normalizeSchemaNonNegativeInteger(value.minContains),
@@ -968,6 +1127,9 @@ function parseSchemaNode(rawNode, displayPath) {
             : undefined,
         patternRegex: type === "string"
             ? metadata.patternRegex
+            : undefined,
+        format: type === "string"
+            ? metadata.format
             : undefined,
         enumValues: normalizeSchemaEnumValues(value.enum),
         refTable: metadata.refTable
@@ -1234,6 +1396,17 @@ function validateNode(schemaNode, yamlNode, displayPath, diagnostics, localizer)
             message: localizeValidationMessage(ValidationMessageKeys.patternViolation, localizer, {
                 displayPath,
                 value: schemaNode.pattern
+            })
+        });
+    }
+
+    if (supportsPatternConstraints &&
+        !matchesSchemaStringFormat(scalarValue, schemaNode.format)) {
+        diagnostics.push({
+            severity: "error",
+            message: localizeValidationMessage(ValidationMessageKeys.formatViolation, localizer, {
+                displayPath,
+                value: schemaNode.format
             })
         });
     }
@@ -1507,6 +1680,11 @@ function matchesSchemaNodeInternal(schemaNode, yamlNode) {
         return false;
     }
 
+    if (supportsPatternConstraints &&
+        !matchesSchemaStringFormat(scalarValue, schemaNode.format)) {
+        return false;
+    }
+
     return typeof schemaNode.constComparableValue !== "string" ||
         buildComparableNodeValue(schemaNode, yamlNode) === schemaNode.constComparableValue;
 }
@@ -1696,6 +1874,8 @@ function localizeValidationMessage(key, localizer, params) {
                 return `属性“${params.displayPath}”应为“${params.schemaType}”，但当前 YAML 结构是“${params.yamlKind}”。`;
             case ValidationMessageKeys.expectedScalarValue:
                 return `属性“${params.displayPath}”应为“${params.schemaType}”，但当前标量值不兼容。`;
+            case ValidationMessageKeys.formatViolation:
+                return `属性“${params.displayPath}”必须满足字符串格式“${params.value}”。`;
             case ValidationMessageKeys.enumMismatch:
                 return `属性“${params.displayPath}”必须是以下值之一：${params.values}。`;
             case ValidationMessageKeys.exclusiveMaximumViolation:
@@ -1742,6 +1922,8 @@ function localizeValidationMessage(key, localizer, params) {
             return `Property '${params.displayPath}' is expected to be '${params.schemaType}', but the current YAML shape is '${params.yamlKind}'.`;
         case ValidationMessageKeys.expectedScalarValue:
             return `Property '${params.displayPath}' is expected to be '${params.schemaType}', but the current scalar value is incompatible.`;
+        case ValidationMessageKeys.formatViolation:
+            return `Property '${params.displayPath}' must satisfy string format '${params.value}'.`;
         case ValidationMessageKeys.enumMismatch:
             return `Property '${params.displayPath}' must be one of: ${params.values}.`;
         case ValidationMessageKeys.exclusiveMaximumViolation:
@@ -2513,6 +2695,7 @@ module.exports = {
  *   maxLength?: number,
  *   pattern?: string,
  *   patternRegex?: RegExp,
+ *   format?: string,
  *   enumValues?: string[],
  *   refTable?: string
  * }} SchemaNode

--- a/tools/gframework-config-tool/src/extension.js
+++ b/tools/gframework-config-tool/src/extension.js
@@ -1578,7 +1578,7 @@ function getScalarArrayValue(yamlNode) {
 /**
  * Render human-facing metadata hints for one schema field.
  *
- * @param {{type?: string, description?: string, defaultValue?: string, constValue?: string, constDisplayValue?: string, minimum?: number, exclusiveMinimum?: number, maximum?: number, exclusiveMaximum?: number, multipleOf?: number, minLength?: number, maxLength?: number, pattern?: string, minItems?: number, maxItems?: number, minContains?: number, maxContains?: number, minProperties?: number, maxProperties?: number, uniqueItems?: boolean, enumValues?: string[], contains?: {type?: string, enumValues?: string[], constValue?: string, constDisplayValue?: string, pattern?: string, refTable?: string}, items?: {enumValues?: string[], constValue?: string, constDisplayValue?: string, minimum?: number, exclusiveMinimum?: number, maximum?: number, exclusiveMaximum?: number, multipleOf?: number, minLength?: number, maxLength?: number, pattern?: string}, refTable?: string}} propertySchema Property schema metadata.
+ * @param {{type?: string, description?: string, defaultValue?: string, constValue?: string, constDisplayValue?: string, minimum?: number, exclusiveMinimum?: number, maximum?: number, exclusiveMaximum?: number, multipleOf?: number, minLength?: number, maxLength?: number, pattern?: string, format?: string, minItems?: number, maxItems?: number, minContains?: number, maxContains?: number, minProperties?: number, maxProperties?: number, uniqueItems?: boolean, enumValues?: string[], contains?: {type?: string, enumValues?: string[], constValue?: string, constDisplayValue?: string, pattern?: string, format?: string, refTable?: string}, items?: {enumValues?: string[], constValue?: string, constDisplayValue?: string, minimum?: number, exclusiveMinimum?: number, maximum?: number, exclusiveMaximum?: number, multipleOf?: number, minLength?: number, maxLength?: number, pattern?: string, format?: string}, refTable?: string}} propertySchema Property schema metadata.
  * @param {boolean} isArrayField Whether the field is an array.
  * @param {boolean} includeDescription Whether description text should be included in the hint output.
  * @returns {string} HTML fragment.
@@ -1639,6 +1639,10 @@ function renderFieldHint(propertySchema, isArrayField, includeDescription = true
 
     if (!isArrayField && propertySchema.pattern) {
         hints.push(escapeHtml(localizer.t("webview.hint.pattern", {value: propertySchema.pattern})));
+    }
+
+    if (!isArrayField && propertySchema.format) {
+        hints.push(escapeHtml(localizer.t("webview.hint.format", {value: propertySchema.format})));
     }
 
     if (propertySchema.type === "object" && typeof propertySchema.minProperties === "number") {
@@ -1708,6 +1712,10 @@ function renderFieldHint(propertySchema, isArrayField, includeDescription = true
 
     if (isArrayField && propertySchema.items && propertySchema.items.pattern) {
         hints.push(escapeHtml(localizer.t("webview.hint.itemPattern", {value: propertySchema.items.pattern})));
+    }
+
+    if (isArrayField && propertySchema.items && propertySchema.items.format) {
+        hints.push(escapeHtml(localizer.t("webview.hint.itemFormat", {value: propertySchema.items.format})));
     }
 
     if (propertySchema.refTable) {

--- a/tools/gframework-config-tool/src/localization.js
+++ b/tools/gframework-config-tool/src/localization.js
@@ -114,6 +114,7 @@ const enMessages = {
     "webview.hint.minLength": "Min length: {value}",
     "webview.hint.maxLength": "Max length: {value}",
     "webview.hint.pattern": "Pattern: {value}",
+    "webview.hint.format": "Format: {value}",
     "webview.hint.minItems": "Min items: {value}",
     "webview.hint.maxItems": "Max items: {value}",
     "webview.hint.contains": "Contains: {summary}",
@@ -129,6 +130,7 @@ const enMessages = {
     "webview.hint.itemMinLength": "Item min length: {value}",
     "webview.hint.itemMaxLength": "Item max length: {value}",
     "webview.hint.itemPattern": "Item pattern: {value}",
+    "webview.hint.itemFormat": "Item format: {value}",
     "webview.hint.minProperties": "Min properties: {value}",
     "webview.hint.maxProperties": "Max properties: {value}",
     "webview.hint.refTable": "Ref table: {refTable}",
@@ -156,6 +158,7 @@ const enMessages = {
     [ValidationMessageKeys.expectedArray]: "Property '{displayPath}' is expected to be an array.",
     [ValidationMessageKeys.expectedScalarShape]: "Property '{displayPath}' is expected to be '{schemaType}', but the current YAML shape is '{yamlKind}'.",
     [ValidationMessageKeys.expectedScalarValue]: "Property '{displayPath}' is expected to be '{schemaType}', but the current scalar value is incompatible.",
+    [ValidationMessageKeys.formatViolation]: "Property '{displayPath}' must satisfy string format '{value}'.",
     [ValidationMessageKeys.missingRequired]: "Required property '{displayPath}' is missing.",
     [ValidationMessageKeys.unknownProperty]: "Property '{displayPath}' is not declared in the matching schema."
 };
@@ -229,6 +232,7 @@ const zhCnMessages = {
     "webview.hint.minLength": "最小长度：{value}",
     "webview.hint.maxLength": "最大长度：{value}",
     "webview.hint.pattern": "正则模式：{value}",
+    "webview.hint.format": "格式：{value}",
     "webview.hint.minItems": "最少元素数：{value}",
     "webview.hint.maxItems": "最多元素数：{value}",
     "webview.hint.contains": "Contains 约束：{summary}",
@@ -244,6 +248,7 @@ const zhCnMessages = {
     "webview.hint.itemMinLength": "元素最小长度：{value}",
     "webview.hint.itemMaxLength": "元素最大长度：{value}",
     "webview.hint.itemPattern": "元素正则模式：{value}",
+    "webview.hint.itemFormat": "元素格式：{value}",
     "webview.hint.minProperties": "最少属性数：{value}",
     "webview.hint.maxProperties": "最多属性数：{value}",
     "webview.hint.refTable": "引用表：{refTable}",
@@ -271,6 +276,7 @@ const zhCnMessages = {
     [ValidationMessageKeys.expectedArray]: "属性“{displayPath}”应为数组。",
     [ValidationMessageKeys.expectedScalarShape]: "属性“{displayPath}”应为“{schemaType}”，但当前 YAML 结构是“{yamlKind}”。",
     [ValidationMessageKeys.expectedScalarValue]: "属性“{displayPath}”应为“{schemaType}”，但当前标量值不兼容。",
+    [ValidationMessageKeys.formatViolation]: "属性“{displayPath}”必须满足字符串格式“{value}”。",
     [ValidationMessageKeys.missingRequired]: "缺少必填属性“{displayPath}”。",
     [ValidationMessageKeys.unknownProperty]: "属性“{displayPath}”未在匹配的 schema 中声明。"
 };

--- a/tools/gframework-config-tool/src/localizationKeys.js
+++ b/tools/gframework-config-tool/src/localizationKeys.js
@@ -7,6 +7,7 @@ const ValidationMessageKeys = Object.freeze({
     expectedObject: "validation.expectedObject",
     expectedScalarShape: "validation.expectedScalarShape",
     expectedScalarValue: "validation.expectedScalarValue",
+    formatViolation: "validation.formatViolation",
     maximumViolation: "validation.maximumViolation",
     maxContainsViolation: "validation.maxContainsViolation",
     maxItemsViolation: "validation.maxItemsViolation",

--- a/tools/gframework-config-tool/test/configValidation.test.js
+++ b/tools/gframework-config-tool/test/configValidation.test.js
@@ -667,6 +667,10 @@ test("validateParsedConfig should enforce supported string formats", () => {
               "type": "string",
               "format": "date"
             },
+            "ancientReleaseDate": {
+              "type": "string",
+              "format": "date"
+            },
             "publishedAt": {
               "type": "string",
               "format": "date-time"
@@ -688,6 +692,7 @@ test("validateParsedConfig should enforce supported string formats", () => {
     `);
     const yaml = parseTopLevelYaml(`
 releaseDate: 2026-02-30
+ancientReleaseDate: 0000-01-01
 publishedAt: 2026-04-11T08:30:00
 contactEmail: boss.example.com
 catalogUri: /loot-table
@@ -696,12 +701,13 @@ configId: 123e4567e89b12d3a456426614174000
 
     const diagnostics = validateParsedConfig(schema, yaml);
 
-    assert.equal(diagnostics.length, 5);
+    assert.equal(diagnostics.length, 6);
     assert.match(diagnostics[0].message, /format 'date'|字符串格式“date”/u);
-    assert.match(diagnostics[1].message, /format 'date-time'|字符串格式“date-time”/u);
-    assert.match(diagnostics[2].message, /format 'email'|字符串格式“email”/u);
-    assert.match(diagnostics[3].message, /format 'uri'|字符串格式“uri”/u);
-    assert.match(diagnostics[4].message, /format 'uuid'|字符串格式“uuid”/u);
+    assert.match(diagnostics[1].message, /format 'date'|字符串格式“date”/u);
+    assert.match(diagnostics[2].message, /format 'date-time'|字符串格式“date-time”/u);
+    assert.match(diagnostics[3].message, /format 'email'|字符串格式“email”/u);
+    assert.match(diagnostics[4].message, /format 'uri'|字符串格式“uri”/u);
+    assert.match(diagnostics[5].message, /format 'uuid'|字符串格式“uuid”/u);
 });
 
 test("validateParsedConfig should accept supported string formats", () => {

--- a/tools/gframework-config-tool/test/configValidation.test.js
+++ b/tools/gframework-config-tool/test/configValidation.test.js
@@ -658,6 +658,91 @@ tags:
     assert.match(diagnostics[2].message, /at least 2 items|至少需要包含 2 个元素/u);
 });
 
+test("validateParsedConfig should enforce supported string formats", () => {
+    const schema = parseSchemaContent(`
+        {
+          "type": "object",
+          "properties": {
+            "releaseDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "publishedAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "contactEmail": {
+              "type": "string",
+              "format": "email"
+            },
+            "catalogUri": {
+              "type": "string",
+              "format": "uri"
+            },
+            "configId": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+    `);
+    const yaml = parseTopLevelYaml(`
+releaseDate: 2026-02-30
+publishedAt: 2026-04-11T08:30:00
+contactEmail: boss.example.com
+catalogUri: /loot-table
+configId: 123e4567e89b12d3a456426614174000
+`);
+
+    const diagnostics = validateParsedConfig(schema, yaml);
+
+    assert.equal(diagnostics.length, 5);
+    assert.match(diagnostics[0].message, /format 'date'|字符串格式“date”/u);
+    assert.match(diagnostics[1].message, /format 'date-time'|字符串格式“date-time”/u);
+    assert.match(diagnostics[2].message, /format 'email'|字符串格式“email”/u);
+    assert.match(diagnostics[3].message, /format 'uri'|字符串格式“uri”/u);
+    assert.match(diagnostics[4].message, /format 'uuid'|字符串格式“uuid”/u);
+});
+
+test("validateParsedConfig should accept supported string formats", () => {
+    const schema = parseSchemaContent(`
+        {
+          "type": "object",
+          "properties": {
+            "releaseDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "publishedAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "contactEmail": {
+              "type": "string",
+              "format": "email"
+            },
+            "catalogUri": {
+              "type": "string",
+              "format": "uri"
+            },
+            "configId": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+    `);
+    const yaml = parseTopLevelYaml(`
+releaseDate: 2026-04-11
+publishedAt: 2026-04-11T08:30:00Z
+contactEmail: boss@example.com
+catalogUri: https://example.com/loot-table
+configId: 123e4567-e89b-12d3-a456-426614174000
+`);
+
+    assert.deepEqual(validateParsedConfig(schema, yaml), []);
+});
+
 test("validateParsedConfig should report exclusive maximum and maxItems violations", () => {
     const schema = parseSchemaContent(`
         {
@@ -1302,6 +1387,30 @@ test("parseSchemaContent should capture exclusive bounds, pattern, and array ite
     assert.equal(schema.properties.tags.items.pattern, "^[a-z]+$");
 });
 
+test("parseSchemaContent should capture supported string format metadata", () => {
+    const schema = parseSchemaContent(`
+        {
+          "type": "object",
+          "properties": {
+            "contactEmail": {
+              "type": "string",
+              "format": "email"
+            },
+            "aliases": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        }
+    `);
+
+    assert.equal(schema.properties.contactEmail.format, "email");
+    assert.equal(schema.properties.aliases.items.format, "uuid");
+});
+
 test("parseSchemaContent should capture multipleOf and uniqueItems metadata", () => {
     const schema = parseSchemaContent(`
         {
@@ -1501,6 +1610,23 @@ test("parseSchemaContent should reject invalid pattern declarations instead of d
             }
         `),
         /invalid 'pattern' regular expression/u
+    );
+});
+
+test("parseSchemaContent should reject unsupported string format declarations", () => {
+    assert.throws(
+        () => parseSchemaContent(`
+            {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "format": "ipv4"
+                }
+              }
+            }
+        `),
+        /unsupported string format 'ipv4'/u
     );
 });
 

--- a/tools/gframework-config-tool/test/configValidation.test.js
+++ b/tools/gframework-config-tool/test/configValidation.test.js
@@ -1630,6 +1630,40 @@ test("parseSchemaContent should reject unsupported string format declarations", 
     );
 });
 
+test("parseSchemaContent should reject format declarations on non-string schema nodes", () => {
+    assert.throws(
+        () => parseSchemaContent(`
+            {
+              "type": "object",
+              "properties": {
+                "hp": {
+                  "type": "integer",
+                  "format": "uuid"
+                }
+              }
+            }
+        `),
+        /can only declare 'format' on type 'string'/u
+    );
+});
+
+test("parseSchemaContent should reject non-string format metadata values", () => {
+    assert.throws(
+        () => parseSchemaContent(`
+            {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "format": 123
+                }
+              }
+            }
+        `),
+        /must declare 'format' as a string/u
+    );
+});
+
 test("parseSchemaContent should ignore mismatched constraint metadata on unsupported scalar types", () => {
     const schema = parseSchemaContent(`
         {


### PR DESCRIPTION
- 新增配置系统详细使用指南，涵盖目录结构、Schema示例、YAML示例
- 添加VS Code插件工具功能说明和推荐接入模板
- 实现配置生成器诊断规则，包括Schema解析、类型检查等错误处理
- 提供运行时加载、热重载、架构集成等完整接入方案
- 添加Godot引擎文本配置桥接和开发期热重载功能说明

## Summary by Sourcery

为运行时、源代码生成器、VS Code 工具和文档新增对一组稳定 JSON Schema 字符串格式子集的共享支持。

新功能：
- 在运行时 YAML 配置验证器和 JS 配置工具中，强制执行并验证 JSON Schema 字符串格式约束（date、date-time、email、uri、uuid）。
- 在生成的配置 XML 文档和 VS Code 字段提示中暴露受支持的字符串格式元数据。

增强：
- 在架构解析和代码生成阶段，一致地拒绝不受支持或无效的字符串格式声明。
- 对齐 C# 运行时与 JS 工具之间关于字符串格式违规的诊断消息和本地化表现。

文档：
- 记录新近支持的共享字符串格式子集，以及它如何参与验证、工具提示和生成文档。

测试：
- 新增运行时和 JS 工具测试，用于覆盖被接受、被拒绝以及不受支持的字符串格式约束，包括生成器诊断。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add shared support for a stable subset of JSON Schema string formats across runtime, source generator, VS Code tooling, and documentation.

New Features:
- Enforce and validate JSON Schema string format constraints (date, date-time, email, uri, uuid) in the runtime YAML config validator and JS config tooling.
- Expose supported string format metadata in generated config XML documentation and VS Code field hints.

Enhancements:
- Reject unsupported or invalid string format declarations consistently at schema-parse and code-generation time.
- Align diagnostic messages and localization for string format violations between C# runtime and JS tooling.

Documentation:
- Document the newly supported shared string format subset and how it participates in validation, tooling hints, and generated docs.

Tests:
- Add runtime and JS tooling tests covering accepted, rejected, and unsupported string format constraints, including generator diagnostics.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 配置系统新增字符串格式约束支持：date、date-time、email、uri、uuid；运行时校验与生成文档均会标注该约束。
* **测试**
  * 增加多项单元测试，覆盖支持/不支持格式、格式用于非字符串及格式类型错误等场景。
* **工具 & 本地化**
  * 校验工具与编辑器提示支持格式校验与界面提示（中/英）。
* **诊断**
  * 新增编译期/运行时错误规则以报告非法或不支持的格式声明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->