### PR TITLE
chore(config): 增加 GitHub 检查超时时间

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,7 +12,7 @@ reviews:
   tools:
     github-checks:
       enabled: true
-      timeout_ms: 90000
+      timeout_ms: 900000
   auto_review:
     enabled: true
     drafts: false # draft PR 不 review


### PR DESCRIPTION
- 将 github-checks 的 timeout_ms 从 90000 增加到 900000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **杂项 (Chores)**
  * 增加了代码审查流程的超时时限配置，以改进审查流程的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->