### PR TITLE
ci(build): 添加CI/CD工作流并修复包依赖配置

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
 
       # 执行NuGet包恢复操作
       - name: Restore
-        run: dotnet restore
+        run: dotnet restore GFramework.sln
       # 恢复.NET本地工具
       - name: Restore .NET tools
         run: dotnet tool restore
@@ -142,49 +142,46 @@ jobs:
         
       # 构建项目，使用Release配置且跳过恢复步骤
       - name: Build
-        run: dotnet build -c Release --no-restore
+        run: dotnet build GFramework.sln -c Release --no-restore
 
       # 运行单元测试，输出TRX格式结果到TestResults目录
       # 在同一个 step 中并发执行所有测试以加快速度
       - name: Test All Projects
         run: |
-          dotnet test GFramework.Core.Tests \
-            -c Release \
-            --no-build \
-            --logger "trx;LogFileName=core-$RANDOM.trx" \
-            --results-directory TestResults &
+          set -euo pipefail
 
-          dotnet test GFramework.Game.Tests \
-            -c Release \
-            --no-build \
-            --logger "trx;LogFileName=game-$RANDOM.trx" \
-            --results-directory TestResults &
+          test_projects=(
+            "GFramework.Core.Tests/GFramework.Core.Tests.csproj:core"
+            "GFramework.Game.Tests/GFramework.Game.Tests.csproj:game"
+            "GFramework.SourceGenerators.Tests/GFramework.SourceGenerators.Tests.csproj:sg"
+            "GFramework.Cqrs.Tests/GFramework.Cqrs.Tests.csproj:cqrs"
+            "GFramework.Ecs.Arch.Tests/GFramework.Ecs.Arch.Tests.csproj:ecs-arch"
+            "GFramework.Godot.Tests/GFramework.Godot.Tests.csproj:godot"
+            "GFramework.Godot.SourceGenerators.Tests/GFramework.Godot.SourceGenerators.Tests.csproj:godot-sg"
+          )
 
-          dotnet test GFramework.SourceGenerators.Tests \
-            -c Release \
-            --no-build \
-            --logger "trx;LogFileName=sg-$RANDOM.trx" \
-            --results-directory TestResults &
+          pids=()
+          for entry in "${test_projects[@]}"; do
+            project="${entry%%:*}"
+            name="${entry##*:}"
 
-          dotnet test GFramework.Cqrs.Tests \
-            -c Release \
-            --no-build \
-            --logger "trx;LogFileName=cqrs-$RANDOM.trx" \
-            --results-directory TestResults &
+            dotnet test "$project" \
+              -c Release \
+              --no-build \
+              --logger "trx;LogFileName=${name}-$RANDOM.trx" \
+              --results-directory TestResults &
 
-          dotnet test GFramework.Ecs.Arch.Tests \
-            -c Release \
-            --no-build \
-            --logger "trx;LogFileName=ecs-arch-$RANDOM.trx" \
-            --results-directory TestResults &
+            pids+=("$!")
+          done
 
-          dotnet test GFramework.Godot.Tests \
-            -c Release \
-            --no-build \
-            --logger "trx;LogFileName=godot-$RANDOM.trx" \
-            --results-directory TestResults &
-          # 等待所有后台测试完成
-          wait
+          failed=0
+          for pid in "${pids[@]}"; do
+            if ! wait "$pid"; then
+              failed=1
+            fi
+          done
+
+          exit "$failed"
           
       - name: Generate CTRF report
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
       # 运行单元测试，输出TRX格式结果到TestResults目录
       # 在同一个 step 中并发执行所有测试以加快速度
       - name: Test All Projects
+        id: test_all_projects
         run: |
           set -euo pipefail
 
@@ -181,7 +182,7 @@ jobs:
             fi
           done
 
-          exit "$failed"
+          echo "failed=$failed" >> "$GITHUB_OUTPUT"
           
       - name: Generate CTRF report
         run: |
@@ -223,3 +224,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
+
+      - name: Fail if any test project failed
+        if: always() && steps.test_all_projects.outputs.failed == '1'
+        run: exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore GFramework.sln
 
       # 从 GitHub 引用中提取标签版本。
       # 提取逻辑：去除 refs/tags/ 前缀，然后去除 v/V 前缀。
@@ -71,7 +71,49 @@ jobs:
         run: |
           set -e
           echo "Packing with version=${{ steps.tag_version.outputs.version }}"
-          dotnet pack -c Release -o ./packages -p:PackageVersion=${{ steps.tag_version.outputs.version }} -p:IncludeSymbols=false
+          dotnet pack GFramework.sln \
+            -c Release \
+            --no-restore \
+            -o ./packages \
+            -p:PackageVersion=${{ steps.tag_version.outputs.version }} \
+            -p:IncludeSymbols=false
+
+      - name: Validate packed modules
+        run: |
+          set -euo pipefail
+
+          expected_packages=(
+            "GeWuYou.GFramework"
+            "GeWuYou.GFramework.Core"
+            "GeWuYou.GFramework.Core.Abstractions"
+            "GeWuYou.GFramework.Core.SourceGenerators"
+            "GeWuYou.GFramework.Cqrs"
+            "GeWuYou.GFramework.Cqrs.Abstractions"
+            "GeWuYou.GFramework.Cqrs.SourceGenerators"
+            "GeWuYou.GFramework.Ecs.Arch"
+            "GeWuYou.GFramework.Ecs.Arch.Abstractions"
+            "GeWuYou.GFramework.Game"
+            "GeWuYou.GFramework.Game.Abstractions"
+            "GeWuYou.GFramework.Game.SourceGenerators"
+            "GeWuYou.GFramework.Godot"
+            "GeWuYou.GFramework.Godot.SourceGenerators"
+          )
+
+          mapfile -t actual_packages < <(
+            find ./packages -maxdepth 1 -type f -name '*.nupkg' -printf '%f\n' \
+              | sed -E 's/\.[0-9][0-9A-Za-z.-]*\.nupkg$//' \
+              | sort -u
+          )
+
+          printf '%s\n' "${expected_packages[@]}" | sort > expected-packages.txt
+          printf '%s\n' "${actual_packages[@]}" | sort > actual-packages.txt
+
+          echo "Expected packages:"
+          cat expected-packages.txt
+          echo "Actual packages:"
+          cat actual-packages.txt
+
+          diff -u expected-packages.txt actual-packages.txt
 
       - name: Show packages
         run: ls -la ./packages || true

--- a/GFramework.Core.SourceGenerators/GFramework.Core.SourceGenerators.csproj
+++ b/GFramework.Core.SourceGenerators/GFramework.Core.SourceGenerators.csproj
@@ -52,7 +52,7 @@
               PackagePath="analyzers/dotnet/cs"
               Visible="false"/>
         <!-- ★ Generator 运行期依赖 -->
-        <None Include="$(OutputPath)\$(AssemblyName).Common.dll"
+        <None Include="$(OutputPath)\GFramework.SourceGenerators.Common.dll"
               Pack="true"
               PackagePath="analyzers/dotnet/cs"
               Visible="false"/>
@@ -61,8 +61,8 @@
     <ItemGroup>
         <None Include="$(OutputPath)\$(AssemblyName).Abstractions.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="true"/>
         <None Include="$(OutputPath)\$(AssemblyName).Abstractions.xml" Pack="true" PackagePath="lib\netstandard2.0" Visible="true"/>
-        <None Include="$(OutputPath)\$(AssemblyName).Common.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="true"/>
-        <None Include="$(OutputPath)\$(AssemblyName).Common.xml" Pack="true" PackagePath="lib\netstandard2.0" Visible="true"/>
+        <None Include="$(OutputPath)\GFramework.SourceGenerators.Common.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="true"/>
+        <None Include="$(OutputPath)\GFramework.SourceGenerators.Common.xml" Pack="true" PackagePath="lib\netstandard2.0" Visible="true"/>
         <None Include="GeWuYou.GFramework.Core.SourceGenerators.targets" Pack="true" PackagePath="build" Visible="false"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
- 配置CI工作流支持PR时执行代码质量检查、构建和测试
- 设置发布工作流支持标签推送时自动打包发布到NuGet和GitHub Packages
- 修复源代码生成器项目的包依赖配置，统一使用GFramework.SourceGenerators.Common命名
- 配置多版本.NET SDK支持及相应的缓存策略
- 实现并行测试执行和统一的测试报告生成机制
- 添加安全扫描和代码质量检查集成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进与优化**
  * 强化了持续集成流程的错误检测与失败上报，构建与测试更可靠
  * 优化了测试执行与并发控制，能更准确汇总并返回测试结果状态
  * 引入包产物校验步骤，确保生成的发布包集合准确且完整
<!-- end of auto-generated comment: release notes by coderabbit.ai -->