### PR TITLE
feat(build): 修改项目构建配置和依赖管理

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+    <!-- Keep repository-wide analyzer behavior consistent while allowing only selected projects to opt into polyfills. -->
+    <ItemGroup>
+        <PackageReference Include="Meziantou.Analyzer" Version="3.0.48">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <PackageReference Update="Meziantou.Polyfill" Version="1.0.110">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+</Project>

--- a/GFramework.Core.Abstractions/Directory.Build.props
+++ b/GFramework.Core.Abstractions/Directory.Build.props
@@ -12,13 +12,7 @@
         <LangVersion>preview</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Meziantou.Analyzer" Version="2.0.264">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Meziantou.Polyfill" Version="1.0.71">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="Meziantou.Polyfill"/>
     </ItemGroup>
+    <Import Project="..\Directory.Build.props" Condition="Exists('..\Directory.Build.props')"/>
 </Project>

--- a/GFramework.Core.Abstractions/GFramework.Core.Abstractions.csproj
+++ b/GFramework.Core.Abstractions/GFramework.Core.Abstractions.csproj
@@ -21,14 +21,6 @@
         <ProjectReference Include="..\GFramework.Cqrs.Abstractions\GFramework.Cqrs.Abstractions.csproj"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="Meziantou.Analyzer" Version="3.0.46">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Update="Meziantou.Polyfill" Version="1.0.110">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6"/>
     </ItemGroup>
 </Project>

--- a/GFramework.Core.SourceGenerators.Abstractions/Directory.Build.props
+++ b/GFramework.Core.SourceGenerators.Abstractions/Directory.Build.props
@@ -12,13 +12,7 @@
         <LangVersion>preview</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Meziantou.Analyzer" Version="2.0.264">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Meziantou.Polyfill" Version="1.0.71">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="Meziantou.Polyfill"/>
     </ItemGroup>
+    <Import Project="..\Directory.Build.props" Condition="Exists('..\Directory.Build.props')"/>
 </Project>

--- a/GFramework.Core.SourceGenerators.Abstractions/GFramework.Core.SourceGenerators.Abstractions.csproj
+++ b/GFramework.Core.SourceGenerators.Abstractions/GFramework.Core.SourceGenerators.Abstractions.csproj
@@ -14,14 +14,4 @@
     <ItemGroup>
         <Using Include="GFramework.Core.SourceGenerators.Abstractions"/>
     </ItemGroup>
-    <ItemGroup>
-        <PackageReference Update="Meziantou.Analyzer" Version="3.0.46">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Update="Meziantou.Polyfill" Version="1.0.103">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
 </Project>

--- a/GFramework.Cqrs.Abstractions/Directory.Build.props
+++ b/GFramework.Cqrs.Abstractions/Directory.Build.props
@@ -6,13 +6,7 @@
         <LangVersion>preview</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Meziantou.Analyzer" Version="3.0.46">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Meziantou.Polyfill" Version="1.0.110">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="Meziantou.Polyfill"/>
     </ItemGroup>
+    <Import Project="..\Directory.Build.props" Condition="Exists('..\Directory.Build.props')"/>
 </Project>

--- a/GFramework.Ecs.Arch.Abstractions/Directory.Build.props
+++ b/GFramework.Ecs.Arch.Abstractions/Directory.Build.props
@@ -6,13 +6,7 @@
         <LangVersion>preview</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Meziantou.Analyzer" Version="2.0.302">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Meziantou.Polyfill" Version="1.0.110">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="Meziantou.Polyfill"/>
     </ItemGroup>
+    <Import Project="..\Directory.Build.props" Condition="Exists('..\Directory.Build.props')"/>
 </Project>

--- a/GFramework.Game.Abstractions/Directory.Build.props
+++ b/GFramework.Game.Abstractions/Directory.Build.props
@@ -12,13 +12,7 @@
         <LangVersion>preview</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Meziantou.Analyzer" Version="2.0.264">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Meziantou.Polyfill" Version="1.0.71">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="Meziantou.Polyfill"/>
     </ItemGroup>
+    <Import Project="..\Directory.Build.props" Condition="Exists('..\Directory.Build.props')"/>
 </Project>

--- a/GFramework.Game.Abstractions/GFramework.Game.Abstractions.csproj
+++ b/GFramework.Game.Abstractions/GFramework.Game.Abstractions.csproj
@@ -19,14 +19,4 @@
     <ItemGroup>
         <Using Include="GFramework.Game.Abstractions"/>
     </ItemGroup>
-    <ItemGroup>
-        <PackageReference Update="Meziantou.Analyzer" Version="3.0.46">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Update="Meziantou.Polyfill" Version="1.0.103">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
 </Project>

--- a/GFramework.Godot.SourceGenerators.Abstractions/Directory.Build.props
+++ b/GFramework.Godot.SourceGenerators.Abstractions/Directory.Build.props
@@ -12,13 +12,7 @@
         <LangVersion>preview</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Meziantou.Analyzer" Version="2.0.264">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Meziantou.Polyfill" Version="1.0.71">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="Meziantou.Polyfill"/>
     </ItemGroup>
+    <Import Project="..\Directory.Build.props" Condition="Exists('..\Directory.Build.props')"/>
 </Project>

--- a/GFramework.Godot.SourceGenerators.Abstractions/GFramework.Godot.SourceGenerators.Abstractions.csproj
+++ b/GFramework.Godot.SourceGenerators.Abstractions/GFramework.Godot.SourceGenerators.Abstractions.csproj
@@ -18,14 +18,4 @@
     <ItemGroup>
         <Folder Include="logging\"/>
     </ItemGroup>
-    <ItemGroup>
-        <PackageReference Update="Meziantou.Analyzer" Version="3.0.46">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Update="Meziantou.Polyfill" Version="1.0.103">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
 </Project>

--- a/GFramework.SourceGenerators.Common/Directory.Build.props
+++ b/GFramework.SourceGenerators.Common/Directory.Build.props
@@ -12,13 +12,7 @@
         <LangVersion>preview</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Meziantou.Analyzer" Version="2.0.264">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Meziantou.Polyfill" Version="1.0.71">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="Meziantou.Polyfill"/>
     </ItemGroup>
+    <Import Project="..\Directory.Build.props" Condition="Exists('..\Directory.Build.props')"/>
 </Project>

--- a/GFramework.SourceGenerators.Common/GFramework.SourceGenerators.Common.csproj
+++ b/GFramework.SourceGenerators.Common/GFramework.SourceGenerators.Common.csproj
@@ -22,14 +22,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all"/>
-        <PackageReference Update="Meziantou.Analyzer" Version="3.0.46">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Update="Meziantou.Polyfill" Version="1.0.103">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="System.Collections.Immutable" Version="9.0.0"/>
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
- 添加 Directory.Build.props 统一构建属性配置
- 配置 netstandard2.0 和 netstandard2.1 目标框架
- 集成 Meziantou.Polyfill 提供新特性支持
- 设置 Nullable 启用可空类型检查
- 配置文档文件生成和包标识设置
- 添加 Microsoft.CodeAnalysis 相关包引用
- 配置项目引用和命名空间引入规则

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 变更日志

* **杂项**
  * 实现构建配置的中央集中管理，统一所有项目的依赖版本配置。
  * 优化项目文件结构，移除冗余的包管理配置以提高构建效率和代码维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->