### PR TITLE
docs: migrate documentation recovery plan into ai-plan

### DIFF
--- a/ai-plan/public/README.md
+++ b/ai-plan/public/README.md
@@ -29,6 +29,10 @@ help the current worktree land on the right recovery documents without scanning 
   - Purpose: continue the CQRS migration, registry hardening, and related PR follow-up.
   - Tracking: `ai-plan/public/cqrs-rewrite/todos/cqrs-rewrite-migration-tracking.md`
   - Trace: `ai-plan/public/cqrs-rewrite/traces/cqrs-rewrite-migration-trace.md`
+- `documentation-governance-and-refresh`
+  - Purpose: continue the documentation governance, README hardening, and `docs/zh-CN` accuracy refresh work.
+  - Tracking: `ai-plan/public/documentation-governance-and-refresh/todos/documentation-governance-and-refresh-tracking.md`
+  - Trace: `ai-plan/public/documentation-governance-and-refresh/traces/documentation-governance-and-refresh-trace.md`
 
 ## Worktree To Active Topic Map
 
@@ -42,6 +46,9 @@ help the current worktree land on the right recovery documents without scanning 
   - Worktree hint: `GFramework-cqrs`
   - Priority 1: `ai-plan-governance`
   - Priority 2: `cqrs-rewrite`
+- Branch: `docs/sdk-update-documentation`
+  - Worktree hint: `GFramework-update-documentation`
+  - Priority 1: `documentation-governance-and-refresh`
 
 ## Archived Topics
 

--- a/ai-plan/public/ai-plan-governance/todos/ai-plan-governance-tracking.md
+++ b/ai-plan/public/ai-plan-governance/todos/ai-plan-governance-tracking.md
@@ -20,7 +20,8 @@
   - 将"主题内 `archive/` 已存在"升级为"active todo/trace 过长时必须归档已完成且已验证阶段"的显式规则
   - 让 active `todos/` / `traces/` 只保留当前恢复点、活跃事实、活跃风险、下一步与 archive 指针
   - 将 `ai-plan-governance`、`ai-first-config-system` 与 `cqrs-rewrite` 的历史阶段从默认启动入口移出
-  - 将当前工作树遗留的 `local-plan` 示例迁入 `ai-plan/public/<topic>/`，验证治理规则对新 topic 迁移同样成立
+  - 将当前工作树遗留的 `local-plan` 示例迁入 `ai-plan/public/<topic>/`，验证治理规则对多个新 topic
+    迁移同样成立
 
 ### 已知风险
 
@@ -49,7 +50,14 @@
   - `ai-plan/public/analyzer-warning-reduction/traces/`
   - `ai-plan/public/analyzer-warning-reduction/archive/todos/`
   - `ai-plan/public/analyzer-warning-reduction/archive/traces/`
+- 已将当前工作树遗留的 documentation governance and refresh 恢复文档从 `local-plan/` 迁入：
+  - `ai-plan/public/documentation-governance-and-refresh/todos/`
+  - `ai-plan/public/documentation-governance-and-refresh/traces/`
+  - `ai-plan/public/documentation-governance-and-refresh/archive/todos/`
+  - `ai-plan/public/documentation-governance-and-refresh/archive/traces/`
 - 已同步更新 `ai-plan/public/README.md`，将分支 `fix/analyzer-warning-reduction-batch` 映射到新 topic
+- 已同步更新 `ai-plan/public/README.md`，将分支 `docs/sdk-update-documentation` 映射到
+  `documentation-governance-and-refresh`
 - 已同步更新 `AGENTS.md`、`ai-plan/README.md` 与 `gframework-boot`，明确 active 文档不是追加式日志，已完成且已验证阶段必须归档
 
 ## 验证
@@ -57,12 +65,18 @@
 - `find ai-plan/public -maxdepth 5 -type f | sort`
   - 结果：通过
   - 备注：活跃主题、主题内归档文件与主题级归档都已按新目录语义落位
-- `wc -l ai-plan/public/ai-plan-governance/todos/ai-plan-governance-tracking.md ai-plan/public/ai-plan-governance/traces/ai-plan-governance-trace.md ai-plan/public/ai-first-config-system/todos/ai-first-config-system-tracking.md ai-plan/public/ai-first-config-system/traces/ai-first-config-system-trace.md ai-plan/public/cqrs-rewrite/todos/cqrs-rewrite-migration-tracking.md ai-plan/public/cqrs-rewrite/traces/cqrs-rewrite-migration-trace.md`
+- `wc -l ai-plan/public/ai-plan-governance/todos/ai-plan-governance-tracking.md ai-plan/public/ai-plan-governance/traces/ai-plan-governance-trace.md ai-plan/public/ai-first-config-system/todos/ai-first-config-system-tracking.md ai-plan/public/ai-first-config-system/traces/ai-first-config-system-trace.md ai-plan/public/cqrs-rewrite/todos/cqrs-rewrite-migration-tracking.md ai-plan/public/cqrs-rewrite/traces/cqrs-rewrite-migration-trace.md ai-plan/public/analyzer-warning-reduction/todos/analyzer-warning-reduction-tracking.md ai-plan/public/analyzer-warning-reduction/traces/analyzer-warning-reduction-trace.md ai-plan/public/documentation-governance-and-refresh/todos/documentation-governance-and-refresh-tracking.md ai-plan/public/documentation-governance-and-refresh/traces/documentation-governance-and-refresh-trace.md`
   - 结果：通过
-  - 备注：6 个 active 入口文件当前合计 `249` 行，已从治理前的 `3046` 行显著收短
+  - 备注：10 个 active 入口文件当前合计 `508` 行，仍保持为按 topic 精简后的恢复入口，而非追加式历史日志
 - `find ai-plan/public/analyzer-warning-reduction -maxdepth 3 -type f | sort`
   - 结果：通过
   - 备注：新 topic 已按 `todos/`、`traces/` 与主题内 `archive/` 目录语义落位
+- `find ai-plan/public/documentation-governance-and-refresh -maxdepth 3 -type f | sort`
+  - 结果：通过
+  - 备注：文档治理 topic 已按 `todos/`、`traces/` 与主题内 `archive/` 目录语义落位
+- `test ! -e local-plan`
+  - 结果：通过
+  - 备注：当前工作树根目录已不再保留 legacy `local-plan/`
 - `dotnet build GFramework.Core.Abstractions/GFramework.Core.Abstractions.csproj -c Release -p:RestoreFallbackFolders=`
   - 结果：通过
   - 备注：`GFramework.Cqrs.Abstractions` 与 `GFramework.Core.Abstractions` 构建通过，`0 warning / 0 error`

--- a/ai-plan/public/ai-plan-governance/traces/ai-plan-governance-trace.md
+++ b/ai-plan/public/ai-plan-governance/traces/ai-plan-governance-trace.md
@@ -47,3 +47,24 @@
 
 1. 后续若再发现 `local-plan` 一类目录，直接按 topic 归属迁入 `ai-plan/public/<topic>/`
 2. 保持新 topic 的 active 入口精简，避免把迁移动作变成简单目录平移
+
+### 阶段：文档治理 local-plan 迁移验证（RP-005）
+
+- 再次复核当前工作树后确认：遗留的 `local-plan/` 内容属于 documentation governance and refresh 主题
+- 按同一治理规则建立 `ai-plan/public/documentation-governance-and-refresh/`，并补齐：
+  - `todos/`
+  - `traces/`
+  - `archive/todos/`
+  - `archive/traces/`
+- 将旧 `local-plan` 中详细的文档治理 todo / trace 收入主题内归档，只保留精简版 active 入口
+- 在 `ai-plan/public/README.md` 中建立
+  `docs/sdk-update-documentation` -> `documentation-governance-and-refresh` 的 worktree 映射
+- 删除旧 `local-plan` 文件，验证当前工作树已无 legacy 根目录恢复入口
+- 额外完成验证：
+  - `find ai-plan/public/documentation-governance-and-refresh -maxdepth 3 -type f | sort`
+  - `test ! -e local-plan`
+
+### 下一步
+
+1. 后续若其他 worktree 仍存在 `local-plan` 一类目录，继续按 topic 归属迁入对应 `ai-plan/public/<topic>/`
+2. 继续保持 topic active 入口精简，避免把迁移后的公共目录重新写成追加式日志

--- a/ai-plan/public/documentation-governance-and-refresh/archive/todos/documentation-governance-and-refresh-history-through-2026-04-18.md
+++ b/ai-plan/public/documentation-governance-and-refresh/archive/todos/documentation-governance-and-refresh-history-through-2026-04-18.md
@@ -1,0 +1,163 @@
+# GFramework 文档治理与重写任务单
+
+> 说明：本归档由 `2026-04-19` 的 `local-plan/` 迁移生成，原历史内容已按当前 `ai-plan` 目录语义做最小整理。
+
+目标：
+
+- 重建 `GFramework` 的总入口、模块入口和 `docs/zh-CN` 采用链路，避免继续传播失真的 API、安装方式和目录结构。
+- 把文档更新责任写入 `AGENTS.md`，避免未来继续出现“新增模块没有 `README.md`”或“改行为不改文档”的回归。
+- 建立主题恢复文档与执行轨迹，让后续 AI 或人工可以在任意阶段无损接手。
+
+阶段完成标准：
+
+- `AGENTS.md` 明确规定 README、docs、示例真实性与恢复文档维护要求
+- 根 `README.md` 与 VitePress 顶层信息架构一致，不再包含错误入口
+- `getting-started` 入口与最小示例不再依赖失真的旧文档
+- 高优先级模块至少补齐或重写以下 README：
+  - `GFramework.Cqrs`
+  - `GFramework.Cqrs.Abstractions`
+  - `GFramework.Game`
+  - `GFramework.Game.Abstractions`
+  - `GFramework.Core`
+  - `GFramework.Core.Abstractions`
+  - `GFramework.Game.SourceGenerators`
+  - `GFramework.Cqrs.SourceGenerators`
+  - `GFramework.Core.SourceGenerators`
+- `docs/zh-CN/abstractions/` 拥有真实 landing page，且导航不再悬空
+
+---
+
+## 事实来源
+
+当前文档工作必须遵守以下证据优先级：
+
+1. 源码、`*.csproj`、包关系、生成器 targets
+2. 测试与 snapshot
+3. `CoreGrid` 的真实接入方式与目录组织
+4. 现有 `README.md` 与 `docs/zh-CN`
+
+说明：
+
+- 旧文档只作为待修输出，不作为行为真相。
+- `CoreGrid` 仅用于补充真实采用路径，不反向定义框架规范。
+
+---
+
+## 当前阶段
+
+Status: 🟡 In Progress
+
+当前阶段目标：
+
+- [x] 建立主题 todo 与 trace
+- [x] 收紧 `AGENTS.md` 文档治理规则
+- [x] 修复根 `README.md` 的信息架构和错误入口
+- [x] 为 `docs/zh-CN/abstractions/` 补 landing page，并接回导航
+- [x] 重写 `getting-started/index.md`
+- [x] 重写 `getting-started/quick-start.md`
+- [x] 补齐 / 重写高优先级模块 README
+- [x] 运行一轮链接与文档存在性校验
+
+---
+
+## P0 必做
+
+### 1. 文档治理规则收口
+
+Status: 🟢 Implemented
+
+- [x] 明确 README 必须随模块建立
+- [x] 明确文档证据优先级
+- [x] 明确根 `README.md` 必须镜像站点 IA
+- [x] 明确文档任务必须维护恢复文档
+
+### 2. 总入口修复
+
+Status: 🟢 Implemented
+
+- [x] 修复根 `README.md` 中不存在的入口
+- [x] 统一文档栏目命名
+- [x] 调整根 README 到栏目 landing page 的链接
+- [x] 校正根 README 中的包选择说明
+
+### 3. 采用链路重写
+
+Status: 🟢 Implemented
+
+- [x] 重写 `docs/zh-CN/getting-started/index.md`
+- [x] 重写 `docs/zh-CN/getting-started/quick-start.md`
+- [x] 为 `abstractions` 栏目补 landing page
+
+### 4. 模块 README 第一批
+
+Status: 🟢 Implemented
+
+- [x] `GFramework.Cqrs`
+- [x] `GFramework.Cqrs.Abstractions`
+- [x] `GFramework.Game`
+- [x] `GFramework.Game.Abstractions`
+- [x] `GFramework.Core`
+- [x] `GFramework.Core.Abstractions`
+- [x] `GFramework.Game.SourceGenerators`
+- [x] `GFramework.Cqrs.SourceGenerators`
+- [x] `GFramework.Core.SourceGenerators`
+
+### 5. 最小化验证
+
+Status: 🟢 Implemented
+
+- [x] 确认旧错误入口 `tutorials/getting-started.md` 不再被引用
+- [x] 确认 `abstractions` landing page 已接回导航
+- [x] 确认第一批高优先级 README 文件均已存在
+- [x] 运行 `bun install`
+- [x] 运行 `bun run build`
+
+---
+
+## 当前恢复点
+
+Recovery Point ID: `doc-refresh-phase0-1-and-module-readmes`
+
+当前推荐恢复步骤：
+
+1. 以 `core/`、`game/`、`source-generators/` 三个栏目为单位继续核对专题页内容真实性
+2. 按栏目整理“旧文档仍失真”的页面清单
+3. 把第二轮重写拆成按栏目推进的 todo
+
+---
+
+## 已接受的并行工作
+
+- `CQRS` README 子任务：补写 `GFramework.Cqrs/README.md` 与 `GFramework.Cqrs.Abstractions/README.md`
+- `Game` README 子任务：重写 `GFramework.Game/README.md` 与 `GFramework.Game.Abstractions/README.md`
+
+已验收结果：
+
+- `CQRS` README 已按当前代码结构补齐运行时、契约层、生成注册表与反射回退协作说明
+- `Game` README 已按运行时实现、契约层边界与 CoreGrid 实际接法重写
+
+主代理负责：
+
+- `AGENTS.md`
+- 根 `README.md`
+- 主题恢复文档
+- `docs/.vitepress/config.mts`
+- `docs/zh-CN/getting-started/*`
+- `docs/zh-CN/abstractions/index.md`
+- `GFramework.Core*` 与 Source Generator 相关 README
+
+---
+
+## 风险与注意事项
+
+- 现有 `docs/zh-CN` 中不少示例看起来“像真的”，但不能直接复用，必须回到代码核实。
+- 根包 `GeWuYou.GFramework` 当前只聚合 `Core` 与 `Game`，文档不能再把它描述为全部模块集合。
+- `LICENSE` 与部分包元数据之间可能存在历史漂移，本轮先以仓库根许可证和当前用户可见入口为准，不顺带修包元数据。
+
+---
+
+## 下一步
+
+- 按栏目继续重写 `docs/zh-CN/core/*`
+- 再推进 `docs/zh-CN/game/*` 与 `docs/zh-CN/source-generators/*`
+- 视内容漂移程度决定是否补第二轮模块 README 或直接切专题页

--- a/ai-plan/public/documentation-governance-and-refresh/archive/traces/documentation-governance-and-refresh-history-through-2026-04-18.md
+++ b/ai-plan/public/documentation-governance-and-refresh/archive/traces/documentation-governance-and-refresh-history-through-2026-04-18.md
@@ -1,0 +1,81 @@
+# GFramework 文档治理执行轨迹
+
+> 说明：本归档由 `2026-04-19` 的 `local-plan/` 迁移生成，原历史内容已按当前 `ai-plan` 目录语义做最小整理。
+
+## 2026-04-18
+
+### 关键事实
+
+- 根 `README.md` 存在错误入口：`docs/zh-CN/tutorials/getting-started.md` 并不存在。
+- VitePress 顶层导航已采用 `getting-started / core / game / godot / tutorials / more` 的信息架构，但根 README
+  仍在使用另一套命名。
+- `docs/zh-CN/abstractions/` 在 sidebar 中已存在分类，但缺少 `index.md` landing page。
+- 多个对外模块缺失 `README.md`，尤其是 `GFramework.Cqrs`、`GFramework.Cqrs.Abstractions`、
+  `GFramework.Game.SourceGenerators`、`GFramework.Cqrs.SourceGenerators`。
+- `GFramework.Game/README.md` 与 `GFramework.Game.Abstractions/README.md` 存在明显失真，无法承担模块入口职责。
+
+### 已执行决策
+
+- 接受“旧文档不可默认信任”的前提，后续文档以代码、测试和 `CoreGrid` 真实用法为准。
+- 保留 `abstractions` 为独立栏目，并为其补 landing page 与导航入口，而不是继续让它悬空。
+- 把根 `README.md` 重写为站点 IA 的 GitHub 镜像入口，不再维护另一套栏目命名。
+- 把 README 命名规范统一为 `README.md`，后续不新增 `ReadMe.md` 变体。
+
+### 并行委派
+
+- 子任务 A：`GFramework.Cqrs/README.md` 与 `GFramework.Cqrs.Abstractions/README.md`
+- 子任务 B：`GFramework.Game/README.md` 与 `GFramework.Game.Abstractions/README.md`
+
+### 已接受的子任务结论
+
+- `GFramework.Cqrs/README.md`
+  - 已按当前 runtime 结构补充 dispatcher、注册器、上下文扩展、source generator 协作与反射回退说明。
+- `GFramework.Cqrs.Abstractions/README.md`
+  - 已明确其仅为协议层，不提供默认 dispatcher 或注册逻辑。
+- `GFramework.Game/README.md`
+  - 已按配置、数据、设置、Scene/UI 路由、存储、序列化等真实运行时子系统重写。
+- `GFramework.Game.Abstractions/README.md`
+  - 已按契约边界、适用场景与 CoreGrid 的真实依赖方式重写。
+
+### 当前主线改动
+
+- 更新 `AGENTS.md` 文档治理规则
+- 建立主题恢复文档
+- 重写根 `README.md`
+- 调整 `docs/.vitepress/config.mts`
+- 重写 `docs/zh-CN/getting-started/index.md`
+- 重写 `docs/zh-CN/getting-started/quick-start.md`
+- 新增 `docs/zh-CN/abstractions/index.md`
+- 重写 `GFramework.Core/README.md`
+- 重写 `GFramework.Core.Abstractions/README.md`
+- 新增 `GFramework.Game.SourceGenerators/README.md`
+- 新增 `GFramework.Cqrs.SourceGenerators/README.md`
+- 重写 `GFramework.Core.SourceGenerators/README.md`
+- 审阅并接纳 `CQRS` / `Game` 两组 README 子任务结果
+
+### 验证结果
+
+- `rg` 校验确认：
+  - 旧错误入口 `docs/zh-CN/tutorials/getting-started.md` 已不再被引用
+  - `docs/zh-CN/getting-started/` 内已无跨到仓库根 README 的相对链接
+- 文件存在性校验确认：
+  - `GFramework.Cqrs`
+  - `GFramework.Cqrs.Abstractions`
+  - `GFramework.Game`
+  - `GFramework.Game.Abstractions`
+  - `GFramework.Core`
+  - `GFramework.Core.Abstractions`
+  - `GFramework.Game.SourceGenerators`
+  - `GFramework.Cqrs.SourceGenerators`
+  - `GFramework.Core.SourceGenerators`
+  均已拥有 `README.md`
+- 文档站验证：
+  - 在 `docs/` 下执行 `bun install`
+  - 在 `docs/` 下执行 `bun run build`
+  - 构建成功；仅出现既有的大 chunk warning，无阻塞错误
+
+### 下一步
+
+- 继续核对 `docs/zh-CN/core/*` 的示例真实性
+- 按栏目推进 `game/*` 与 `source-generators/*` 的专题页重写
+- 视专题页真实情况决定第二轮是否拆分新的恢复子任务

--- a/ai-plan/public/documentation-governance-and-refresh/todos/documentation-governance-and-refresh-tracking.md
+++ b/ai-plan/public/documentation-governance-and-refresh/todos/documentation-governance-and-refresh-tracking.md
@@ -1,0 +1,54 @@
+# Documentation Governance And Refresh 跟踪
+
+## 目标
+
+继续以“文档必须可追溯到源码、测试与真实接入方式”为原则，收敛 `GFramework` 的仓库入口、模块入口与
+`docs/zh-CN` 采用链路，避免未来再次出现 API、安装方式与目录结构失真。
+
+## 当前恢复点
+
+- 恢复点编号：`DOCUMENTATION-GOVERNANCE-REFRESH-RP-001`
+- 当前阶段：`Phase 1`
+- 当前焦点：
+  - 已将当前工作树根目录的 legacy `local-plan/` 迁入 `ai-plan/public/documentation-governance-and-refresh/`
+  - 第一轮治理已完成 `AGENTS.md`、根 `README.md`、`getting-started` 与第一批高优先级模块 `README.md`
+  - 下一轮需要继续按栏目核对并重写 `docs/zh-CN/core/*`、`docs/zh-CN/game/*` 与
+    `docs/zh-CN/source-generators/*`
+
+## 当前状态摘要
+
+- 文档治理规则已收口到仓库规范，README、站点入口与采用链路不再依赖旧文档自证
+- 高优先级模块入口已补齐，首轮文档站构建校验已经通过
+- 当前主题仍是 active topic，因为核心栏目专题页仍可能包含与实现漂移的旧内容
+
+## 当前活跃事实
+
+- 旧 `local-plan/` 的详细 todo 与 trace 已迁入主题内 `archive/`
+- 当前分支 `docs/sdk-update-documentation` 已在 `ai-plan/public/README.md` 建立 topic 映射
+- active 跟踪文件只保留当前恢复点、活跃事实、风险与下一步，不再重复保存已完成阶段的长篇历史
+
+## 当前风险
+
+- 旧专题页示例失真风险：`docs/zh-CN/core/*`、`game/*` 与 `source-generators/*` 中仍可能保留看似合理但与
+  真实实现不一致的示例
+  - 缓解措施：继续按源码、测试、`*.csproj` 与 `CoreGrid` 真实接法核对，不把旧文档当事实来源
+- 采用路径误导风险：根聚合包与模块边界若再次被写错，会继续误导消费者的包选择
+  - 缓解措施：保持“源码与包关系优先”的证据顺序，改动采用说明时同步核对包依赖与生成器 wiring
+- Active 入口回膨胀风险：后续若把栏目级重写过程直接追加到 active 文档，会再次拖慢恢复
+  - 缓解措施：阶段完成并验证后，继续把细节迁入本 topic 的 `archive/`
+
+## 活跃文档
+
+- 历史跟踪归档：[documentation-governance-and-refresh-history-through-2026-04-18.md](../archive/todos/documentation-governance-and-refresh-history-through-2026-04-18.md)
+- 历史 trace 归档：[documentation-governance-and-refresh-history-through-2026-04-18.md](../archive/traces/documentation-governance-and-refresh-history-through-2026-04-18.md)
+
+## 验证说明
+
+- 旧 `local-plan/` 的详细实施历史与文档站构建结果已迁入主题内归档
+- active 跟踪文件已按 `ai-plan` 治理规则精简为当前恢复入口
+
+## 下一步
+
+1. 继续按栏目核对 `docs/zh-CN/core/*`，列出仍失真的页面与示例
+2. 再推进 `docs/zh-CN/game/*` 与 `docs/zh-CN/source-generators/*` 的专题页重写
+3. 若下一轮重写完成且验证通过，将栏目级详细过程迁入本 topic 的 `archive/`

--- a/ai-plan/public/documentation-governance-and-refresh/traces/documentation-governance-and-refresh-trace.md
+++ b/ai-plan/public/documentation-governance-and-refresh/traces/documentation-governance-and-refresh-trace.md
@@ -1,0 +1,31 @@
+# Documentation Governance And Refresh 追踪
+
+## 2026-04-19
+
+### 阶段：local-plan 迁移收口（RP-001）
+
+- 复核当前工作树后确认：worktree 根目录仅剩一个 legacy `local-plan/`，其内容属于文档治理与重写主题的
+  durable recovery state，不应继续作为独立根目录入口存在
+- 按 `ai-plan` 治理规则建立 `ai-plan/public/documentation-governance-and-refresh/` 主题目录，并补齐：
+  - `todos/`
+  - `traces/`
+  - `archive/todos/`
+  - `archive/traces/`
+- 将原 `local-plan` 中的详细 tracking / trace 迁入主题内历史归档，并为 active 入口只保留当前恢复点、
+  活跃事实、风险与下一步
+- 在 `ai-plan/public/README.md` 中建立
+  `docs/sdk-update-documentation` -> `documentation-governance-and-refresh` 的 worktree 映射
+- 同步更新 `ai-plan-governance` 的 tracking / trace，记录本次迁移已验证当前工作树不再依赖 worktree-root
+  `local-plan/`
+
+### Archive Context
+
+- 历史跟踪归档：
+  - `ai-plan/public/documentation-governance-and-refresh/archive/todos/documentation-governance-and-refresh-history-through-2026-04-18.md`
+- 历史 trace 归档：
+  - `ai-plan/public/documentation-governance-and-refresh/archive/traces/documentation-governance-and-refresh-history-through-2026-04-18.md`
+
+### 下一步
+
+1. 后续继续该主题时，只从 `ai-plan/public/documentation-governance-and-refresh/` 进入，不再恢复 `local-plan/`
+2. 若 active 入口再次积累多轮已完成且已验证阶段，继续按同一模式迁入该主题自己的 `archive/`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 新增文档治理和刷新主题，包括追踪流程、验证步骤及治理规则
  * 更新索引映射，优化文档分支工作流管理
  * 建立文档归档机制，记录历史变更和治理决策

* **其他**
  * 扩展项目治理范围，涵盖多个文档主题的迁移和验证

<!-- end of auto-generated comment: release notes by coderabbit.ai -->