### PR TITLE
fix(release): 修复发布说明变更汇总标题

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -54,6 +54,9 @@ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
 
 {% endif -%}
 
+{% if commits | length > 0 -%}
+## What's Changed
+
 {% for group, commits in commits | group_by(attribute="group") -%}
 ### {{ group | striptags | trim }}
 {% for commit in commits -%}
@@ -61,6 +64,7 @@ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
 {% endfor %}
 
 {% endfor -%}
+{% endif -%}
 
 {% if previous and previous.version and version -%}
 Full Changelog: [{{ previous.version }}...{{ version }}]({{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }})

--- a/ai-plan/public/README.md
+++ b/ai-plan/public/README.md
@@ -62,6 +62,9 @@ help the current worktree land on the right recovery documents without scanning 
 - Branch: `feat/semantic-release-versioning`
   - Worktree hint: `GFramework`
   - Priority 1: `semantic-release-versioning`
+- Branch: `feat/release-summary-notes`
+  - Worktree hint: `GFramework`
+  - Priority 1: `semantic-release-versioning`
 - Branch: `docs/sdk-update-documentation`
   - Worktree hint: `GFramework-update-documentation`
   - Priority 1: `documentation-full-coverage-governance`

--- a/ai-plan/public/semantic-release-versioning/todos/semantic-release-versioning-tracking.md
+++ b/ai-plan/public/semantic-release-versioning/todos/semantic-release-versioning-tracking.md
@@ -16,9 +16,9 @@
 - 恢复点编号：`SEMREL-RP-004`
 - 当前阶段：`Phase 2`
 - 当前焦点：
-  - 收敛 PR #312 最新 AI review 的 release notes 输出问题
-  - 确保 `.github/cliff.toml` 不再重复输出同一批 commits
-  - 确保 `publish.yml` 创建 GitHub Release 时通过文件传递多行 release notes
+  - 收敛 release notes 的 PR 归属展示方式
+  - 确保 `.github/cliff.toml` 不新增独立 PR 索引导致重复输出同一批 commits
+  - 让分类变更列表本身承担 `What's Changed` 语义，并继续在每条 entry 末尾展示作者与 PR 链接
 
 ### 已知风险
 
@@ -45,14 +45,21 @@
   CodeRabbit / Greptile 针对 release notes 的未解决线程
 - 已移除 `.github/cliff.toml` 中 `## What's Changed` 下的未分组 commit 循环，仅保留按 Conventional Commit group
   分类后的输出，避免每个 commit 在生成的 changelog 中出现两次
+- 已将 `.github/cliff.toml` 的分类变更列表重新置于 `## What's Changed` 下，但没有恢复未分组平铺列表；
+  每条变更继续通过 `print_commit` 输出 `by @user in #PR` 链接，满足 PR 追溯需求同时避免重复章节
 - 已将 `.github/workflows/publish.yml` 的 GitHub Release 正文从多行 expression 改为 `body_path: RELEASE_NOTES.md`，
   复用 `git-cliff-action` 写出的 release notes 文件
+- 已在 `ai-plan/public/README.md` 中将 `feat/release-summary-notes` 映射到 `semantic-release-versioning`，便于后续
+  `boot` 直接找到本次发布说明模板上下文
 
 ## 验证
 
 - `python3 -c 'import tomllib; tomllib.load(open(".github/cliff.toml", "rb")); print("cliff.toml OK")'`
   - 结果：通过
   - 备注：确认 `.github/cliff.toml` 仍为合法 TOML
+- `command -v git-cliff`
+  - 结果：未找到本地 `git-cliff`
+  - 备注：本地无法直接预览 git-cliff 输出，发布 workflow 仍通过 `orhun/git-cliff-action@v4` 提供运行时二进制
 - `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/publish.yml", encoding="utf-8")); print("publish.yml OK")'`
   - 结果：通过
   - 备注：确认 `.github/workflows/publish.yml` 仍可解析为 YAML
@@ -61,12 +68,11 @@
   - 备注：确认 release step 现在使用 `body_path: RELEASE_NOTES.md`
 - `dotnet build GFramework.sln -c Release`
   - 结果：通过
-  - 备注：Release 构建通过，`0 warning / 0 error`；本轮只改动 GitHub Actions / git-cliff 配置
+  - 备注：Release 构建通过，`0 warning / 0 error`；本轮只改动 GitHub Actions / git-cliff 配置与恢复文档
 - 更早阶段的 dry-run / tag /抽象项目验证已归档到
   `ai-plan/public/semantic-release-versioning/archive/todos/semantic-release-versioning-2026-04-26.md`
 
 ## 下一步
 
-1. 提交并推送本轮 PR review 修复
-2. 重新抓取 PR review，确认 CodeRabbit / Greptile 的 release notes open threads 已转为过时或可关闭
-3. 如 CI 仍报告 release notes 发布问题，再优先复查 `git-cliff-action` 输出文件路径与 `action-gh-release` 输入契约
+1. 提交并推送本轮 release notes 模板调整
+2. 如 CI 仍报告 release notes 发布问题，再优先复查 `git-cliff-action` 输出文件路径与模板渲染结果

--- a/ai-plan/public/semantic-release-versioning/traces/semantic-release-versioning-trace.md
+++ b/ai-plan/public/semantic-release-versioning/traces/semantic-release-versioning-trace.md
@@ -2,6 +2,21 @@
 
 ## 2026-05-01
 
+### 发布说明 PR 归属展示（SEMREL-RP-004）
+
+- 本轮取舍：
+  - 不新增单独 PR 索引章节，避免和分类变更列表重复展示同一批 PR
+  - 保留 `print_commit` 的 `by @user in #PR` 输出，让每条变更直接具备 PR 追溯入口
+  - 在 grouped 分类列表外层补回 `## What's Changed`，让该区域明确承担完整变更清单语义
+- 已更新：
+  - `.github/cliff.toml`：分类变更列表现在位于 `## What's Changed` 下，未恢复旧的未分组 commit 循环
+  - `ai-plan/public/README.md`：新增 `feat/release-summary-notes` 到 `semantic-release-versioning` 的 active topic 映射
+- 验证：
+  - `.github/cliff.toml` 通过 Python `tomllib` 解析
+  - 本地未安装 `git-cliff`，无法直接预览 action 渲染输出
+  - `dotnet build GFramework.sln -c Release` 通过，`0 warning / 0 error`
+- 下一步是提交并推送本轮 release notes 模板调整。
+
 ### 当前恢复点（SEMREL-RP-004）
 
 - 通过 `$gframework-pr-review` 抓取当前分支 PR #312：


### PR DESCRIPTION
- 修复 git-cliff 模板的 What's Changed 归属，让分类变更列表承担完整变更清单语义

- 保留 每条变更末尾的作者与 PR 链接，避免新增独立 PR 索引造成重复展示

- 更新 semantic-release-versioning 恢复文档与当前分支映射

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改进

* **发布说明**
  * 优化了发布说明的生成逻辑，在没有相关变更时不再显示空的部分，使发布说明内容更加清晰简洁。

* **流程优化**
  * 完善了版本发布工作流配置，增强发布流程的稳定性和可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->