### PR TITLE
build(release): 支持依赖与安全提交触发补丁发布

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -34,6 +34,14 @@
             "release": "patch"
           },
           {
+            "type": "deps",
+            "release": "patch"
+          },
+          {
+            "type": "security",
+            "release": "patch"
+          },
+          {
             "type": "docs",
             "release": false
           },

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -78,6 +78,45 @@
       "@semantic-release/release-notes-generator",
       {
         "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            {
+              "type": "feat",
+              "section": "Features",
+              "hidden": false
+            },
+            {
+              "type": "fix",
+              "section": "Bug Fixes",
+              "hidden": false
+            },
+            {
+              "type": "perf",
+              "section": "Performance Improvements",
+              "hidden": false
+            },
+            {
+              "type": "refactor",
+              "section": "Refactoring",
+              "hidden": false
+            },
+            {
+              "type": "deps",
+              "section": "Dependency Updates",
+              "hidden": false
+            },
+            {
+              "type": "security",
+              "section": "Security Fixes",
+              "hidden": false
+            },
+            {
+              "type": "revert",
+              "section": "Reverts",
+              "hidden": false
+            }
+          ]
+        },
         "parserOpts": {
           "noteKeywords": [
             "BREAKING CHANGE",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,10 @@ All AI agents and contributors must follow these rules when writing, reviewing, 
     `minor` segment.
   - Use `fix` for behavior corrections, `perf` for observable performance improvements, and `refactor` only for
     non-feature code restructuring; these should raise the next released version's `patch` segment.
+  - Use `deps` for dependency version updates, dependency lockfile refreshes, and package maintenance that should raise
+    the next released version's `patch` segment.
+  - Use `security` for vulnerability fixes, dependency security mitigations, and security configuration corrections
+    that should raise the next released version's `patch` segment.
   - Use `docs`、`test`、`chore`、`build`、`ci`、`style` for their literal categories; do not encode these changes as
     `feat` just because they feel important. These categories MUST NOT trigger a release.
   - Use `BREAKING CHANGE` in the commit footer or `!` after the type / scope header (for example `feat!:` or

--- a/ai-plan/public/README.md
+++ b/ai-plan/public/README.md
@@ -62,6 +62,9 @@ help the current worktree land on the right recovery documents without scanning 
 - Branch: `feat/semantic-release-versioning`
   - Worktree hint: `GFramework`
   - Priority 1: `semantic-release-versioning`
+- Branch: `build/semantic-release-rules`
+  - Worktree hint: `GFramework`
+  - Priority 1: `semantic-release-versioning`
 - Branch: `docs/sdk-update-documentation`
   - Worktree hint: `GFramework-update-documentation`
   - Priority 1: `documentation-full-coverage-governance`

--- a/ai-plan/public/semantic-release-versioning/todos/semantic-release-versioning-tracking.md
+++ b/ai-plan/public/semantic-release-versioning/todos/semantic-release-versioning-tracking.md
@@ -8,17 +8,17 @@
 - 用 `cycjimmy/semantic-release-action` 替换 `auto-tag.yml` 的版本判断和打 tag 逻辑
 - 保留 `publish.yml` 的现有发布实现，不重写 NuGet 流程
 - 避免 `semantic-release` 与 `publish.yml` 重复创建 GitHub Release
-- 将版本规则固定为 `feat -> minor`、`fix/perf/refactor -> patch`、`BREAKING CHANGE` 或 `! -> major`
+- 将版本规则固定为 `feat -> minor`、`fix/perf/refactor/deps/security -> patch`、`BREAKING CHANGE` 或 `! -> major`
 - 为手动 `workflow_dispatch` 保留 dry-run 验证入口，先验证最近提交会算出什么版本
 
 ## 当前恢复点
 
-- 恢复点编号：暂无
-- 当前阶段：等待下一轮 semantic-release 维护任务
+- 恢复点编号：SEMREL-RP-005
+- 当前阶段：扩展 patch 级提交类型规则
 - 当前焦点：
-  - `SEMREL-RP-004` 已归档到
-    `ai-plan/public/semantic-release-versioning/archive/todos/semantic-release-versioning-rp004-2026-05-02.md`
-  - 后续如 CI 或发布流程继续暴露 semantic-release 问题，再从新的恢复点编号开始记录
+  - `.releaserc.json` 增加 `deps -> patch` 与 `security -> patch`
+  - `AGENTS.md` 和 `docs/zh-CN/contributing.md` 同步提交类型说明
+  - `build/semantic-release-rules` 分支映射到当前 active topic
 
 ### 已知风险
 
@@ -26,6 +26,7 @@
 - `semantic-release` preview 虽然不会真实推送 tag，但仍会执行远端 `git push --dry-run` 权限探测；如果 PAT 仅具备
   read 权限、没有 `contents:write`，仍然会先于版本分析阶段失败
 - `semantic-release` 的版本判断完全依赖 Conventional Commits；不规范提交会直接影响版本计算
+- `deps` 和 `security` 的发布语义需要同时维护在 `.releaserc.json`、`AGENTS.md` 和公开贡献文档中，避免规则漂移
 - `cycjimmy/semantic-release-action@v6` 需要在 preview / release 两端都安装 `conventional-changelog-conventionalcommits`
   以保证 `conventionalcommits` preset 在 GitHub Actions 中可解析
 - `git-cliff-action` 的 `OUTPUT` 文件需要在 `softprops/action-gh-release` 执行时保留在当前工作目录，后续如调整
@@ -45,10 +46,15 @@
 ## 验证
 
 - `SEMREL-RP-004` 的本地验证结果已归档。
+- `SEMREL-RP-005` 已完成本地验证：
+  - `jq . .releaserc.json` 通过
+  - `semantic-release --dry-run --no-ci` 已成功加载 `commit-analyzer` 和 `release-notes-generator`，随后因远端 tag
+    fetch 会 clobber 本地既有 tags 而终止，未暴露配置解析错误
+  - `dotnet build GFramework.sln -c Release` 通过，`0 warning / 0 error`
 - 更早阶段的 dry-run / tag /抽象项目验证已归档到
   `ai-plan/public/semantic-release-versioning/archive/todos/semantic-release-versioning-2026-04-26.md`
 
 ## 下一步
 
-1. 如 CI 仍报告 release notes 发布问题，再优先复查 `git-cliff-action` 输出文件路径与模板渲染结果
-2. 下一轮 semantic-release 调整开始时创建新的恢复点编号
+1. 将本轮规则扩展与跟踪文档更新提交到 `build/semantic-release-rules`
+2. 如后续需要完整 semantic-release 版本预览，先处理本地 tag 与远端 tag 的 clobber 冲突

--- a/ai-plan/public/semantic-release-versioning/todos/semantic-release-versioning-tracking.md
+++ b/ai-plan/public/semantic-release-versioning/todos/semantic-release-versioning-tracking.md
@@ -13,10 +13,11 @@
 
 ## 当前恢复点
 
-- 恢复点编号：SEMREL-RP-005
-- 当前阶段：扩展 patch 级提交类型规则
+- 恢复点编号：SEMREL-RP-006
+- 当前阶段：处理 PR review 中的 release notes 类型映射漂移
 - 当前焦点：
-  - `.releaserc.json` 增加 `deps -> patch` 与 `security -> patch`
+  - `.releaserc.json` 的 `release-notes-generator` 增加 `presetConfig.types`
+  - 让 `refactor`、`deps` 与 `security` 这类 patch 级发布原因出现在 semantic-release 生成的 notes 中
   - `AGENTS.md` 和 `docs/zh-CN/contributing.md` 同步提交类型说明
   - `build/semantic-release-rules` 分支映射到当前 active topic
 
@@ -26,7 +27,8 @@
 - `semantic-release` preview 虽然不会真实推送 tag，但仍会执行远端 `git push --dry-run` 权限探测；如果 PAT 仅具备
   read 权限、没有 `contents:write`，仍然会先于版本分析阶段失败
 - `semantic-release` 的版本判断完全依赖 Conventional Commits；不规范提交会直接影响版本计算
-- `deps` 和 `security` 的发布语义需要同时维护在 `.releaserc.json`、`AGENTS.md` 和公开贡献文档中，避免规则漂移
+- patch 级提交类型的发布语义需要同时维护在 `.releaserc.json`、`AGENTS.md`、公开贡献文档和
+  `release-notes-generator` 的 notes 类型映射中，避免版本升级原因与 workflow summary 漂移
 - `cycjimmy/semantic-release-action@v6` 需要在 preview / release 两端都安装 `conventional-changelog-conventionalcommits`
   以保证 `conventionalcommits` preset 在 GitHub Actions 中可解析
 - `git-cliff-action` 的 `OUTPUT` 文件需要在 `softprops/action-gh-release` 执行时保留在当前工作目录，后续如调整
@@ -42,6 +44,8 @@
 - 已为 PAT 校验的 `mktemp` 文件补充 `trap` 清理，避免异常退出时遗留临时文件路径干扰日志
 - `SEMREL-RP-004` 的 release notes 模板修复、验证和合并后分支收尾已归档到
   `ai-plan/public/semantic-release-versioning/archive/todos/semantic-release-versioning-rp004-2026-05-02.md`
+- `SEMREL-RP-005` 已扩展 `deps` / `security` 的 patch 发布规则，并同步提交规范文档
+- `SEMREL-RP-006` 已根据 PR review 复核结果补齐 release notes 类型映射，避免 patch 发布原因只触发版本而不进入 notes
 
 ## 验证
 
@@ -51,10 +55,15 @@
   - `semantic-release --dry-run --no-ci` 已成功加载 `commit-analyzer` 和 `release-notes-generator`，随后因远端 tag
     fetch 会 clobber 本地既有 tags 而终止，未暴露配置解析错误
   - `dotnet build GFramework.sln -c Release` 通过，`0 warning / 0 error`
+- `SEMREL-RP-006` 已完成本地验证：
+  - `jq . .releaserc.json` 通过
+  - `semantic-release --dry-run --no-ci` 已成功加载 `commit-analyzer` 和 `release-notes-generator`，随后因远端 tag
+    fetch 会 clobber 本地既有 tags 而终止，未暴露 `presetConfig.types` 配置解析错误
+  - `dotnet build GFramework.sln -c Release` 通过，`0 warning / 0 error`
 - 更早阶段的 dry-run / tag /抽象项目验证已归档到
   `ai-plan/public/semantic-release-versioning/archive/todos/semantic-release-versioning-2026-04-26.md`
 
 ## 下一步
 
-1. 将本轮规则扩展与跟踪文档更新提交到 `build/semantic-release-rules`
+1. 提交 `SEMREL-RP-006` 的 PR review 修复
 2. 如后续需要完整 semantic-release 版本预览，先处理本地 tag 与远端 tag 的 clobber 冲突

--- a/ai-plan/public/semantic-release-versioning/traces/semantic-release-versioning-trace.md
+++ b/ai-plan/public/semantic-release-versioning/traces/semantic-release-versioning-trace.md
@@ -1,5 +1,31 @@
 # Semantic Release 版本迁移追踪
 
+## 2026-05-04
+
+### PR review notes 类型映射修复（SEMREL-RP-006）
+
+- 通过 `$gframework-pr-review` 抓取当前分支 PR #319：
+  - CodeRabbit 在最新 review body 中提出 1 个 nitpick，指出 `deps` / `security` 已触发 patch，但
+    `release-notes-generator` 缺少 `presetConfig.types`，workflow summary 可能看不到对应发布原因
+  - 最新 head commit 没有未解决 review threads
+  - CTRF 测试报告显示 `2264 passed / 0 failed`
+  - 未找到 MegaLinter 明细块
+- 本地复核结论：
+  - `.releaserc.json` 的 `commit-analyzer` 已配置 `deps -> patch` 与 `security -> patch`
+  - `release-notes-generator` 仍只配置 `conventionalcommits` preset 和 `parserOpts.noteKeywords`
+  - 该 drift 会让 patch 级发布原因与 release notes 可读性不一致，评论成立
+- 已应用修复：
+  - `.releaserc.json` 为 `release-notes-generator` 增加 `presetConfig.types`
+  - `feat`、`fix`、`perf`、`refactor`、`deps`、`security` 和 `revert` 均保留可见 notes section
+- 验证：
+  - `jq . .releaserc.json` 通过
+  - `npx --yes -p semantic-release -p conventional-changelog-conventionalcommits@9.1.0 semantic-release --dry-run --no-ci`
+    成功加载 `commit-analyzer` 和 `release-notes-generator`；随后在 `git fetch --tags` 阶段因远端 tag 会 clobber
+    本地既有 tags 而终止，未暴露 `presetConfig.types` 配置解析错误
+  - `dotnet build GFramework.sln -c Release` 通过，`0 warning / 0 error`
+- 下一步是提交本轮 PR review 修复；如后续需要完整 semantic-release 版本预览，先处理本地 tag 与远端 tag 的
+  clobber 冲突。
+
 ## 2026-05-03
 
 ### patch 级提交类型扩展（SEMREL-RP-005）

--- a/ai-plan/public/semantic-release-versioning/traces/semantic-release-versioning-trace.md
+++ b/ai-plan/public/semantic-release-versioning/traces/semantic-release-versioning-trace.md
@@ -1,5 +1,26 @@
 # Semantic Release 版本迁移追踪
 
+## 2026-05-03
+
+### patch 级提交类型扩展（SEMREL-RP-005）
+
+- 本轮目标：
+  - 允许 `deps` 提交触发 patch 发布，用于依赖版本、依赖锁定和包维护变更
+  - 允许 `security` 提交触发 patch 发布，用于安全修复、漏洞缓解和安全配置修正
+  - 同步 `.releaserc.json`、`AGENTS.md`、公开贡献文档和 active topic 映射，避免 release 规则与提交规范漂移
+- 已更新：
+  - `.releaserc.json`：新增 `deps -> patch` 和 `security -> patch`
+  - `AGENTS.md`：补充 `deps` / `security` 的 release 语义
+  - `docs/zh-CN/contributing.md`：补充公开贡献指南中的 Type 说明
+  - `ai-plan/public/README.md`：新增 `build/semantic-release-rules` 到 `semantic-release-versioning` 的分支映射
+- 验证：
+  - `jq . .releaserc.json` 通过
+  - `npx --yes -p semantic-release -p conventional-changelog-conventionalcommits@9.1.0 semantic-release --dry-run --no-ci`
+    成功加载 `commit-analyzer` 和 `release-notes-generator`；随后在 `git fetch --tags` 阶段因远端 tag 会 clobber
+    本地既有 tags 而终止，未暴露本轮配置解析错误
+  - `dotnet build GFramework.sln -c Release` 通过，`0 warning / 0 error`
+- 下一步是提交本轮规则扩展；如后续需要完整 semantic-release 版本预览，先处理本地 tag 与远端 tag 的 clobber 冲突。
+
 ## 2026-05-01
 
 ### 发布说明 PR 归属展示（SEMREL-RP-004）

--- a/docs/zh-CN/contributing.md
+++ b/docs/zh-CN/contributing.md
@@ -334,6 +334,8 @@ public TModel RegisterModel&lt;TModel&gt;(TModel model) where TModel : IModel
 - **style**：代码格式调整（不影响功能）
 - **refactor**：重构（不是新功能也不是修复）
 - **perf**：性能优化
+- **deps**：依赖版本、依赖锁定或包维护变更
+- **security**：安全修复、漏洞缓解或安全配置修正
 - **test**：添加或修改测试
 - **chore**：构建过程或辅助工具的变动
 - **ci**：CI 配置文件和脚本的变动


### PR DESCRIPTION
- 更新 semantic-release 规则，将 deps 与 security 提交映射为 patch 发布

- 补充 AGENTS 与贡献文档中的提交类型语义

- 记录 SEMREL-RP-005 验证结果与分支恢复入口

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 将依赖（deps）与安全（security）类提交纳入补丁（patch）发布规则，并确保这些类型在发布说明中作为可见节展示（“Dependency Updates”、“Security Fixes”）。
* **Documentation**
  * 更新贡献指南与相关文档，新增 deps 类型说明并同步语义化版本规则与发布说明映射。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->