### PR TITLE
fix(release): 修复发布说明 PR 链接缺失

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       published: ${{ steps.semantic_release.outputs.new_release_published }}
       last_tag: ${{ steps.semantic_release.outputs.last_release_git_tag }}
@@ -108,6 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
     environment:
       name: release-approval
     steps:

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           OUTPUT: PREVIEW_RELEASE_NOTES.md
           GITHUB_REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Write preview summary
         env:
@@ -159,7 +159,7 @@ jobs:
         env:
           OUTPUT: PUBLISHED_RELEASE_NOTES.md
           GITHUB_REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Write release summary
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -243,6 +243,7 @@ jobs:
     permissions:
       contents: write
       packages: read
+      pull-requests: read
 
     steps:
       - name: Checkout repository (at tag)

--- a/ai-plan/public/README.md
+++ b/ai-plan/public/README.md
@@ -65,6 +65,9 @@ help the current worktree land on the right recovery documents without scanning 
 - Branch: `build/semantic-release-rules`
   - Worktree hint: `GFramework`
   - Priority 1: `semantic-release-versioning`
+- Branch: `fix/release-notes-pr-links`
+  - Worktree hint: `GFramework`
+  - Priority 1: `semantic-release-versioning`
 - Branch: `docs/sdk-update-documentation`
   - Worktree hint: `GFramework-update-documentation`
   - Priority 1: `documentation-full-coverage-governance`

--- a/ai-plan/public/semantic-release-versioning/todos/semantic-release-versioning-tracking.md
+++ b/ai-plan/public/semantic-release-versioning/todos/semantic-release-versioning-tracking.md
@@ -13,13 +13,13 @@
 
 ## 当前恢复点
 
-- 恢复点编号：SEMREL-RP-006
-- 当前阶段：处理 PR review 中的 release notes 类型映射漂移
+- 恢复点编号：SEMREL-RP-007
+- 当前阶段：修复 git-cliff 发布说明 PR 链接缺失
 - 当前焦点：
-  - `.releaserc.json` 的 `release-notes-generator` 增加 `presetConfig.types`
-  - 让 `refactor`、`deps` 与 `security` 这类 patch 级发布原因出现在 semantic-release 生成的 notes 中
-  - `AGENTS.md` 和 `docs/zh-CN/contributing.md` 同步提交类型说明
-  - `build/semantic-release-rules` 分支映射到当前 active topic
+  - `.github/workflows/auto-tag.yml` 的 preview / release job 增加 `pull-requests: read`
+  - `.github/workflows/publish.yml` 的 GitHub Release job 增加 `pull-requests: read`
+  - 保持 `.github/cliff.toml` 的 `by @user in #PR` 模板不变，只补足 GitHub PR 元数据读取权限
+  - `fix/release-notes-pr-links` 分支映射到当前 active topic
 
 ### 已知风险
 
@@ -33,6 +33,8 @@
   以保证 `conventionalcommits` preset 在 GitHub Actions 中可解析
 - `git-cliff-action` 的 `OUTPUT` 文件需要在 `softprops/action-gh-release` 执行时保留在当前工作目录，后续如调整
   working-directory 或 artifact 路径，需要同步复查 `body_path`
+- `git-cliff-action` 依赖 GitHub API 补充 `commit.remote.pr_number`；生成 release notes 的 workflow job 必须具备
+  `pull-requests: read`，否则模板只能稳定输出作者，不能稳定输出 `in #PR`
 
 ## 已完成
 
@@ -46,6 +48,8 @@
   `ai-plan/public/semantic-release-versioning/archive/todos/semantic-release-versioning-rp004-2026-05-02.md`
 - `SEMREL-RP-005` 已扩展 `deps` / `security` 的 patch 发布规则，并同步提交规范文档
 - `SEMREL-RP-006` 已根据 PR review 复核结果补齐 release notes 类型映射，避免 patch 发布原因只触发版本而不进入 notes
+- `SEMREL-RP-007` 已为所有 `git-cliff-action` release notes 生成 job 补齐 PR 读取权限，避免未来 GitHub Release
+  正文缺失 PR 链接
 
 ## 验证
 
@@ -60,10 +64,15 @@
   - `semantic-release --dry-run --no-ci` 已成功加载 `commit-analyzer` 和 `release-notes-generator`，随后因远端 tag
     fetch 会 clobber 本地既有 tags 而终止，未暴露 `presetConfig.types` 配置解析错误
   - `dotnet build GFramework.sln -c Release` 通过，`0 warning / 0 error`
+- `SEMREL-RP-007` 已完成本地验证：
+  - workflow 权限静态检查通过，所有 `git-cliff-action` 所在 job 均声明 `pull-requests: read`
+  - `.github/cliff.toml` 通过 Python `tomllib` 解析
+  - `python3 scripts/license-header.py --check` 通过
+  - `dotnet build GFramework.sln -c Release` 通过，`0 warning / 0 error`
 - 更早阶段的 dry-run / tag /抽象项目验证已归档到
   `ai-plan/public/semantic-release-versioning/archive/todos/semantic-release-versioning-2026-04-26.md`
 
 ## 下一步
 
-1. 提交 `SEMREL-RP-006` 的 PR review 修复
-2. 如后续需要完整 semantic-release 版本预览，先处理本地 tag 与远端 tag 的 clobber 冲突
+1. 提交 `SEMREL-RP-007` 的 workflow 权限修复
+2. 如后续需要回填当前 GitHub Release 正文，使用带 PR read 权限的 GitHub CLI 或 API token 重新生成并更新 notes

--- a/ai-plan/public/semantic-release-versioning/todos/semantic-release-versioning-tracking.md
+++ b/ai-plan/public/semantic-release-versioning/todos/semantic-release-versioning-tracking.md
@@ -17,6 +17,8 @@
 - 当前阶段：修复 git-cliff 发布说明 PR 链接缺失
 - 当前焦点：
   - `.github/workflows/auto-tag.yml` 的 preview / release job 增加 `pull-requests: read`
+  - `.github/workflows/auto-tag.yml` 的 `git-cliff-action` 改用 `${{ github.token }}` 读取 PR 元数据，`PAT_TOKEN`
+    只保留给 `semantic-release` 的 dry-run push 探测与真实打 tag
   - `.github/workflows/publish.yml` 的 GitHub Release job 增加 `pull-requests: read`
   - 保持 `.github/cliff.toml` 的 `by @user in #PR` 模板不变，只补足 GitHub PR 元数据读取权限
   - `fix/release-notes-pr-links` 分支映射到当前 active topic
@@ -35,6 +37,8 @@
   working-directory 或 artifact 路径，需要同步复查 `body_path`
 - `git-cliff-action` 依赖 GitHub API 补充 `commit.remote.pr_number`；生成 release notes 的 workflow job 必须具备
   `pull-requests: read`，否则模板只能稳定输出作者，不能稳定输出 `in #PR`
+- `auto-tag.yml` 中 job 级 `permissions` 只约束 `${{ github.token }}`，不约束 `${{ secrets.PAT_TOKEN }}`；生成
+  release notes 时必须使用 `${{ github.token }}` 才能让 `pull-requests: read` 声明真正生效
 
 ## 已完成
 
@@ -48,8 +52,8 @@
   `ai-plan/public/semantic-release-versioning/archive/todos/semantic-release-versioning-rp004-2026-05-02.md`
 - `SEMREL-RP-005` 已扩展 `deps` / `security` 的 patch 发布规则，并同步提交规范文档
 - `SEMREL-RP-006` 已根据 PR review 复核结果补齐 release notes 类型映射，避免 patch 发布原因只触发版本而不进入 notes
-- `SEMREL-RP-007` 已为所有 `git-cliff-action` release notes 生成 job 补齐 PR 读取权限，避免未来 GitHub Release
-  正文缺失 PR 链接
+- `SEMREL-RP-007` 已为所有 `git-cliff-action` release notes 生成 job 补齐 PR 读取权限，并让 `auto-tag.yml`
+  的 `git-cliff-action` 改用 `${{ github.token }}`，避免未来 GitHub Release 正文缺失 PR 链接
 
 ## 验证
 
@@ -65,7 +69,8 @@
     fetch 会 clobber 本地既有 tags 而终止，未暴露 `presetConfig.types` 配置解析错误
   - `dotnet build GFramework.sln -c Release` 通过，`0 warning / 0 error`
 - `SEMREL-RP-007` 已完成本地验证：
-  - workflow 权限静态检查通过，所有 `git-cliff-action` 所在 job 均声明 `pull-requests: read`
+  - workflow 权限静态检查通过，所有 `git-cliff-action` 所在 job 均使用具备 `pull-requests: read` 的
+    `${{ github.token }}`
   - `.github/cliff.toml` 通过 Python `tomllib` 解析
   - `python3 scripts/license-header.py --check` 通过
   - `dotnet build GFramework.sln -c Release` 通过，`0 warning / 0 error`
@@ -74,5 +79,5 @@
 
 ## 下一步
 
-1. 提交 `SEMREL-RP-007` 的 workflow 权限修复
+1. 推送 `SEMREL-RP-007` 的 PR review 修复，并重新抓取 PR review 确认重复标题线程和 PAT token 说明已收敛
 2. 如后续需要回填当前 GitHub Release 正文，使用带 PR read 权限的 GitHub CLI 或 API token 重新生成并更新 notes

--- a/ai-plan/public/semantic-release-versioning/traces/semantic-release-versioning-trace.md
+++ b/ai-plan/public/semantic-release-versioning/traces/semantic-release-versioning-trace.md
@@ -2,6 +2,31 @@
 
 ## 2026-05-04
 
+### 发布说明 PR 链接权限修复（SEMREL-RP-007）
+
+- 触发原因：
+  - v0.3.0 GitHub Release 中多数条目只显示 `by @GeWuYou`，没有 `in #xxx`
+  - `.github/cliff.toml` 的 `print_commit` 只有在 `commit.remote.pr_number` 存在时才追加 PR 链接
+  - `auto-tag.yml` 与 `publish.yml` 的 `git-cliff-action` job 只声明了 `contents` / `packages` 权限，没有显式
+    `pull-requests: read`
+- 本地复核结论：
+  - 模板本身已经包含 `by @user in #PR` 输出，不需要改 release notes 格式
+  - 修复点应放在 workflow permissions，确保 git-cliff 能通过 GitHub API 稳定补全 PR 元数据
+  - 当前环境未安装 `git-cliff` 或 `gh`，无法在本地直接重渲染并回填已发布的 GitHub Release 正文
+- 已应用修复：
+  - `.github/workflows/auto-tag.yml` 的 preview / release job 增加 `pull-requests: read`
+  - `.github/workflows/publish.yml` 的 `create-release` job 增加 `pull-requests: read`
+  - `ai-plan/public/README.md` 新增 `fix/release-notes-pr-links` 到 `semantic-release-versioning` 的 active topic 映射
+- 验证：
+  - workflow 权限静态检查通过，所有 `git-cliff-action` 所在 job 均声明 `pull-requests: read`
+  - `.github/cliff.toml` 通过 Python `tomllib` 解析
+  - `python3 scripts/license-header.py --check` 通过
+  - `dotnet build GFramework.sln -c Release` 通过，`0 warning / 0 error`
+- 下一步是提交本轮 workflow 权限修复；如需回填 v0.3.0 Release 正文，需要在具备 `git-cliff` / `gh`
+  或 GitHub release API 能力的环境中执行。
+
+## 2026-05-04
+
 ### PR review notes 类型映射修复（SEMREL-RP-006）
 
 - 通过 `$gframework-pr-review` 抓取当前分支 PR #319：

--- a/ai-plan/public/semantic-release-versioning/traces/semantic-release-versioning-trace.md
+++ b/ai-plan/public/semantic-release-versioning/traces/semantic-release-versioning-trace.md
@@ -9,23 +9,26 @@
   - `.github/cliff.toml` 的 `print_commit` 只有在 `commit.remote.pr_number` 存在时才追加 PR 链接
   - `auto-tag.yml` 与 `publish.yml` 的 `git-cliff-action` job 只声明了 `contents` / `packages` 权限，没有显式
     `pull-requests: read`
+  - PR review 补充指出 `auto-tag.yml` 里的 `git-cliff-action` 实际接收 `PAT_TOKEN`，job 级 `pull-requests: read`
+    不会约束该 token
 - 本地复核结论：
   - 模板本身已经包含 `by @user in #PR` 输出，不需要改 release notes 格式
-  - 修复点应放在 workflow permissions，确保 git-cliff 能通过 GitHub API 稳定补全 PR 元数据
+  - `publish.yml` 已对 `git-cliff-action` 使用 `${{ github.token }}`，job 级 `pull-requests: read` 能直接生效
+  - `auto-tag.yml` 应仅让 `semantic-release` 继续使用 `PAT_TOKEN`，让 `git-cliff-action` 改用带 job 权限的
+    `${{ github.token }}`，避免 PR 元数据读取能力取决于 PAT 创建时的额外 scope
   - 当前环境未安装 `git-cliff` 或 `gh`，无法在本地直接重渲染并回填已发布的 GitHub Release 正文
 - 已应用修复：
   - `.github/workflows/auto-tag.yml` 的 preview / release job 增加 `pull-requests: read`
+  - `.github/workflows/auto-tag.yml` 的 preview / release `git-cliff-action` 改用 `${{ github.token }}`
   - `.github/workflows/publish.yml` 的 `create-release` job 增加 `pull-requests: read`
   - `ai-plan/public/README.md` 新增 `fix/release-notes-pr-links` 到 `semantic-release-versioning` 的 active topic 映射
 - 验证：
-  - workflow 权限静态检查通过，所有 `git-cliff-action` 所在 job 均声明 `pull-requests: read`
+  - workflow 权限静态检查通过，所有 `git-cliff-action` 所在 job 均使用具备 `pull-requests: read` 的 `${{ github.token }}`
   - `.github/cliff.toml` 通过 Python `tomllib` 解析
   - `python3 scripts/license-header.py --check` 通过
   - `dotnet build GFramework.sln -c Release` 通过，`0 warning / 0 error`
-- 下一步是提交本轮 workflow 权限修复；如需回填 v0.3.0 Release 正文，需要在具备 `git-cliff` / `gh`
-  或 GitHub release API 能力的环境中执行。
-
-## 2026-05-04
+- 下一步是推送本轮 PR review 修复并重新抓取 PR review，确认重复标题线程和 PAT token 说明已收敛；如需回填
+  v0.3.0 Release 正文，需要在具备 `git-cliff` / `gh` 或 GitHub release API 能力的环境中执行。
 
 ### PR review notes 类型映射修复（SEMREL-RP-006）
 


### PR DESCRIPTION
- 修复 release notes 生成 job 缺少 PR 读取权限的问题

- 更新 semantic-release 主题恢复点与验证记录

- 补充当前修复分支到 ai-plan 启动映射

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **修复**
  * 修复了发布说明中拉取请求链接的显示问题，GitHub Releases 现在能正确呈现关联的 PR 链接。

* **文档**
  * 更新了发布/版本计划与追踪文档，记录了为确保发布说明完整性所做的权限与验证调整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->