### PR TITLE
fix(godot): 增加主线程同步cqrs保护

### DIFF
--- a/GFramework.Godot.Tests/Architectures/AbstractArchitectureModuleInstallationTests.cs
+++ b/GFramework.Godot.Tests/Architectures/AbstractArchitectureModuleInstallationTests.cs
@@ -22,18 +22,30 @@ namespace GFramework.Godot.Tests.Architectures;
 [TestFixture]
 public sealed class AbstractArchitectureModuleInstallationTests
 {
+    /// <summary>
+    ///     验证主线程同步 CQRS 保护启用时，请求与查询入口都会抛出异常，并给出对应的异步迁移指引。
+    /// </summary>
     [Test]
     public void GodotArchitectureContext_ShouldThrow_ForSyncCqrsCalls_WhenGuardIsActive()
     {
         var context = new GodotArchitectureContext(new ArchitectureContext(new GFramework.Core.Ioc.MicrosoftDiContainer()), () => true);
 
-        var exception = Assert.Throws<InvalidOperationException>(() =>
+        var requestException = Assert.Throws<InvalidOperationException>(() =>
             context.SendRequest(new TestRequest()));
+        var queryException = Assert.Throws<InvalidOperationException>(() =>
+            context.SendQuery(new TestLegacyQuery()));
 
-        Assert.That(exception, Is.Not.Null);
-        Assert.That(exception!.Message, Does.Contain("SendAsync(...)"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(requestException!.Message, Does.Contain("SendRequestAsync(...)"));
+            Assert.That(requestException.Message, Does.Contain("SendAsync(...)"));
+            Assert.That(queryException!.Message, Does.Contain("SendQueryAsync(...)"));
+        });
     }
 
+    /// <summary>
+    ///     验证主线程同步 CQRS 保护关闭时，请求入口会继续委托到底层上下文。
+    /// </summary>
     [Test]
     public void GodotArchitectureContext_ShouldForwardSyncCqrsCalls_WhenGuardIsInactive()
     {
@@ -44,6 +56,9 @@ public sealed class AbstractArchitectureModuleInstallationTests
         Assert.That(result, Is.EqualTo("ok"));
     }
 
+    /// <summary>
+    ///     验证未显式传入上下文时，架构默认会包装成带 Godot 主线程保护的上下文实现。
+    /// </summary>
     [Test]
     public void AbstractArchitecture_ShouldUseGodotContextWrapper_ByDefault()
     {
@@ -89,86 +104,103 @@ public sealed class AbstractArchitectureModuleInstallationTests
 
     private sealed class ForwardingArchitectureContext : IArchitectureContext
     {
+        /// <inheritdoc />
         public TService GetService<TService>() where TService : class
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public IReadOnlyList<TService> GetServices<TService>() where TService : class
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public TSystem GetSystem<TSystem>() where TSystem : class, ISystem
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public IReadOnlyList<TSystem> GetSystems<TSystem>() where TSystem : class, ISystem
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public TModel GetModel<TModel>() where TModel : class, IModel
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public IReadOnlyList<TModel> GetModels<TModel>() where TModel : class, IModel
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public TUtility GetUtility<TUtility>() where TUtility : class, IUtility
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public IReadOnlyList<TUtility> GetUtilities<TUtility>() where TUtility : class, IUtility
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public IReadOnlyList<TService> GetServicesByPriority<TService>() where TService : class
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public IReadOnlyList<TSystem> GetSystemsByPriority<TSystem>() where TSystem : class, ISystem
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public IReadOnlyList<TModel> GetModelsByPriority<TModel>() where TModel : class, IModel
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public IReadOnlyList<TUtility> GetUtilitiesByPriority<TUtility>() where TUtility : class, IUtility
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public void SendCommand(ICommand command)
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public TResult SendCommand<TResult>(ICommand<TResult> command)
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public TResponse SendCommand<TResponse>(GFramework.Cqrs.Abstractions.Cqrs.Command.ICommand<TResponse> command)
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public Task SendCommandAsync(IAsyncCommand command)
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public ValueTask<TResponse> SendCommandAsync<TResponse>(
             GFramework.Cqrs.Abstractions.Cqrs.Command.ICommand<TResponse> command,
             CancellationToken cancellationToken = default)
@@ -176,26 +208,31 @@ public sealed class AbstractArchitectureModuleInstallationTests
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public Task<TResult> SendCommandAsync<TResult>(IAsyncCommand<TResult> command)
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public TResult SendQuery<TResult>(IQuery<TResult> query)
         {
-            throw new NotSupportedException();
+            return (TResult)(object)"ok";
         }
 
+        /// <inheritdoc />
         public TResponse SendQuery<TResponse>(GFramework.Cqrs.Abstractions.Cqrs.Query.IQuery<TResponse> query)
         {
-            throw new NotSupportedException();
+            return (TResponse)(object)"ok";
         }
 
+        /// <inheritdoc />
         public Task<TResult> SendQueryAsync<TResult>(IAsyncQuery<TResult> query)
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public ValueTask<TResponse> SendQueryAsync<TResponse>(
             GFramework.Cqrs.Abstractions.Cqrs.Query.IQuery<TResponse> query,
             CancellationToken cancellationToken = default)
@@ -203,31 +240,37 @@ public sealed class AbstractArchitectureModuleInstallationTests
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public void SendEvent<TEvent>() where TEvent : new()
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public void SendEvent<TEvent>(TEvent e) where TEvent : class
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public IUnRegister RegisterEvent<TEvent>(Action<TEvent> handler)
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public void UnRegisterEvent<TEvent>(Action<TEvent> onEvent)
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public IEnvironment GetEnvironment()
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public ValueTask<TResponse> SendRequestAsync<TResponse>(
             IRequest<TResponse> request,
             CancellationToken cancellationToken = default)
@@ -235,11 +278,13 @@ public sealed class AbstractArchitectureModuleInstallationTests
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public TResponse SendRequest<TResponse>(IRequest<TResponse> request)
         {
             return (TResponse)(object)"ok";
         }
 
+        /// <inheritdoc />
         public ValueTask PublishAsync<TNotification>(
             TNotification notification,
             CancellationToken cancellationToken = default)
@@ -248,6 +293,7 @@ public sealed class AbstractArchitectureModuleInstallationTests
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public IAsyncEnumerable<TResponse> CreateStream<TResponse>(
             IStreamRequest<TResponse> request,
             CancellationToken cancellationToken = default)
@@ -255,12 +301,14 @@ public sealed class AbstractArchitectureModuleInstallationTests
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public ValueTask SendAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
             where TCommand : IRequest<Unit>
         {
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc />
         public ValueTask<TResponse> SendAsync<TResponse>(
             IRequest<TResponse> command,
             CancellationToken cancellationToken = default)
@@ -290,4 +338,24 @@ public sealed class AbstractArchitectureModuleInstallationTests
     }
 
     private sealed class TestRequest : IRequest<string>;
+
+    private sealed class TestLegacyQuery : IQuery<string>
+    {
+        private IArchitectureContext? _context;
+
+        public void SetContext(IArchitectureContext context)
+        {
+            _context = context;
+        }
+
+        public IArchitectureContext GetContext()
+        {
+            return _context!;
+        }
+
+        public string Do()
+        {
+            return "ok";
+        }
+    }
 }

--- a/GFramework.Godot.Tests/Architectures/AbstractArchitectureModuleInstallationTests.cs
+++ b/GFramework.Godot.Tests/Architectures/AbstractArchitectureModuleInstallationTests.cs
@@ -64,8 +64,6 @@ public sealed class AbstractArchitectureModuleInstallationTests
     {
         var architecture = new TestArchitecture();
 
-        architecture.Initialize();
-
         Assert.That(architecture.Context, Is.TypeOf<GodotArchitectureContext>());
     }
 

--- a/GFramework.Godot.Tests/Architectures/AbstractArchitectureModuleInstallationTests.cs
+++ b/GFramework.Godot.Tests/Architectures/AbstractArchitectureModuleInstallationTests.cs
@@ -2,7 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using GFramework.Core.Abstractions.Architectures;
+using GFramework.Core.Abstractions.Command;
+using GFramework.Core.Abstractions.Environment;
+using GFramework.Core.Abstractions.Events;
+using GFramework.Core.Abstractions.Model;
+using GFramework.Core.Abstractions.Query;
+using GFramework.Core.Abstractions.Systems;
+using GFramework.Core.Abstractions.Utility;
+using GFramework.Core.Architectures;
 using GFramework.Godot.Architectures;
+using GFramework.Cqrs.Abstractions.Cqrs;
+using ICommand = GFramework.Core.Abstractions.Command.ICommand;
 
 namespace GFramework.Godot.Tests.Architectures;
 
@@ -12,6 +22,38 @@ namespace GFramework.Godot.Tests.Architectures;
 [TestFixture]
 public sealed class AbstractArchitectureModuleInstallationTests
 {
+    [Test]
+    public void GodotArchitectureContext_ShouldThrow_ForSyncCqrsCalls_WhenGuardIsActive()
+    {
+        var context = new GodotArchitectureContext(new ArchitectureContext(new GFramework.Core.Ioc.MicrosoftDiContainer()), () => true);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            context.SendRequest(new TestRequest()));
+
+        Assert.That(exception, Is.Not.Null);
+        Assert.That(exception!.Message, Does.Contain("SendAsync(...)"));
+    }
+
+    [Test]
+    public void GodotArchitectureContext_ShouldForwardSyncCqrsCalls_WhenGuardIsInactive()
+    {
+        var context = new GodotArchitectureContext(new ForwardingArchitectureContext(), () => false);
+
+        var result = context.SendRequest(new TestRequest());
+
+        Assert.That(result, Is.EqualTo("ok"));
+    }
+
+    [Test]
+    public void AbstractArchitecture_ShouldUseGodotContextWrapper_ByDefault()
+    {
+        var architecture = new TestArchitecture();
+
+        architecture.Initialize();
+
+        Assert.That(architecture.Context, Is.TypeOf<GodotArchitectureContext>());
+    }
+
     /// <summary>
     ///     验证当锚点尚未初始化时，安装流程会直接失败，且不会执行模块安装逻辑。
     /// </summary>
@@ -45,6 +87,188 @@ public sealed class AbstractArchitectureModuleInstallationTests
         }
     }
 
+    private sealed class ForwardingArchitectureContext : IArchitectureContext
+    {
+        public TService GetService<TService>() where TService : class
+        {
+            throw new NotSupportedException();
+        }
+
+        public IReadOnlyList<TService> GetServices<TService>() where TService : class
+        {
+            throw new NotSupportedException();
+        }
+
+        public TSystem GetSystem<TSystem>() where TSystem : class, ISystem
+        {
+            throw new NotSupportedException();
+        }
+
+        public IReadOnlyList<TSystem> GetSystems<TSystem>() where TSystem : class, ISystem
+        {
+            throw new NotSupportedException();
+        }
+
+        public TModel GetModel<TModel>() where TModel : class, IModel
+        {
+            throw new NotSupportedException();
+        }
+
+        public IReadOnlyList<TModel> GetModels<TModel>() where TModel : class, IModel
+        {
+            throw new NotSupportedException();
+        }
+
+        public TUtility GetUtility<TUtility>() where TUtility : class, IUtility
+        {
+            throw new NotSupportedException();
+        }
+
+        public IReadOnlyList<TUtility> GetUtilities<TUtility>() where TUtility : class, IUtility
+        {
+            throw new NotSupportedException();
+        }
+
+        public IReadOnlyList<TService> GetServicesByPriority<TService>() where TService : class
+        {
+            throw new NotSupportedException();
+        }
+
+        public IReadOnlyList<TSystem> GetSystemsByPriority<TSystem>() where TSystem : class, ISystem
+        {
+            throw new NotSupportedException();
+        }
+
+        public IReadOnlyList<TModel> GetModelsByPriority<TModel>() where TModel : class, IModel
+        {
+            throw new NotSupportedException();
+        }
+
+        public IReadOnlyList<TUtility> GetUtilitiesByPriority<TUtility>() where TUtility : class, IUtility
+        {
+            throw new NotSupportedException();
+        }
+
+        public void SendCommand(ICommand command)
+        {
+            throw new NotSupportedException();
+        }
+
+        public TResult SendCommand<TResult>(ICommand<TResult> command)
+        {
+            throw new NotSupportedException();
+        }
+
+        public TResponse SendCommand<TResponse>(GFramework.Cqrs.Abstractions.Cqrs.Command.ICommand<TResponse> command)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task SendCommandAsync(IAsyncCommand command)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask<TResponse> SendCommandAsync<TResponse>(
+            GFramework.Cqrs.Abstractions.Cqrs.Command.ICommand<TResponse> command,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<TResult> SendCommandAsync<TResult>(IAsyncCommand<TResult> command)
+        {
+            throw new NotSupportedException();
+        }
+
+        public TResult SendQuery<TResult>(IQuery<TResult> query)
+        {
+            throw new NotSupportedException();
+        }
+
+        public TResponse SendQuery<TResponse>(GFramework.Cqrs.Abstractions.Cqrs.Query.IQuery<TResponse> query)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<TResult> SendQueryAsync<TResult>(IAsyncQuery<TResult> query)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask<TResponse> SendQueryAsync<TResponse>(
+            GFramework.Cqrs.Abstractions.Cqrs.Query.IQuery<TResponse> query,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void SendEvent<TEvent>() where TEvent : new()
+        {
+            throw new NotSupportedException();
+        }
+
+        public void SendEvent<TEvent>(TEvent e) where TEvent : class
+        {
+            throw new NotSupportedException();
+        }
+
+        public IUnRegister RegisterEvent<TEvent>(Action<TEvent> handler)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void UnRegisterEvent<TEvent>(Action<TEvent> onEvent)
+        {
+            throw new NotSupportedException();
+        }
+
+        public IEnvironment GetEnvironment()
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask<TResponse> SendRequestAsync<TResponse>(
+            IRequest<TResponse> request,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public TResponse SendRequest<TResponse>(IRequest<TResponse> request)
+        {
+            return (TResponse)(object)"ok";
+        }
+
+        public ValueTask PublishAsync<TNotification>(
+            TNotification notification,
+            CancellationToken cancellationToken = default)
+            where TNotification : INotification
+        {
+            throw new NotSupportedException();
+        }
+
+        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(
+            IStreamRequest<TResponse> request,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask SendAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
+            where TCommand : IRequest<Unit>
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask<TResponse> SendAsync<TResponse>(
+            IRequest<TResponse> command,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
     private sealed class RecordingGodotModule : IGodotModule
     {
         public bool InstallCalled { get; private set; }
@@ -64,4 +288,6 @@ public sealed class AbstractArchitectureModuleInstallationTests
         {
         }
     }
+
+    private sealed class TestRequest : IRequest<string>;
 }

--- a/GFramework.Godot/Architectures/AbstractArchitecture.cs
+++ b/GFramework.Godot/Architectures/AbstractArchitecture.cs
@@ -17,6 +17,16 @@ public abstract class AbstractArchitecture : Architecture
     /// <summary>
     ///     初始化新的 Godot 架构，并为未显式提供上下文的场景自动启用 Godot 主线程同步 CQRS 保护。
     /// </summary>
+    /// <param name="configuration">可选的架构配置；当为 <see langword="null" /> 时沿用基类默认配置解析流程。</param>
+    /// <param name="environment">可选的运行环境实例；当为 <see langword="null" /> 时由基类按默认规则解析。</param>
+    /// <param name="services">可选的服务容器包装；若未提供，则创建新的 <see cref="ArchitectureServices" />。</param>
+    /// <param name="context">
+    ///     可选的架构上下文；若未提供，则自动包装为 <see cref="GodotArchitectureContext" />，
+    ///     以确保默认同步 CQRS 调用在 Godot 主线程上受到保护。
+    /// </param>
+    /// <remarks>
+    ///     该构造函数会让默认服务实例与默认上下文共享同一容器，避免模块安装阶段出现服务注册与解析容器不一致的问题。
+    /// </remarks>
     protected AbstractArchitecture(
         IArchitectureConfiguration? configuration = null,
         IEnvironment? environment = null,

--- a/GFramework.Godot/Architectures/AbstractArchitecture.cs
+++ b/GFramework.Godot/Architectures/AbstractArchitecture.cs
@@ -12,13 +12,20 @@ namespace GFramework.Godot.Architectures;
 ///     抽象架构类，为特定类型的架构提供基础实现框架。
 ///     此类负责管理架构的初始化、生命周期绑定以及扩展模块的安装与销毁。
 /// </summary>
-public abstract class AbstractArchitecture(
-    IArchitectureConfiguration? configuration = null,
-    IEnvironment? environment = null,
-    IArchitectureServices? services = null,
-    IArchitectureContext? context = null
-) : Architecture(configuration, environment, services, context)
+public abstract class AbstractArchitecture : Architecture
 {
+    /// <summary>
+    ///     初始化新的 Godot 架构，并为未显式提供上下文的场景自动启用 Godot 主线程同步 CQRS 保护。
+    /// </summary>
+    protected AbstractArchitecture(
+        IArchitectureConfiguration? configuration = null,
+        IEnvironment? environment = null,
+        IArchitectureServices? services = null,
+        IArchitectureContext? context = null)
+        : this(ResolveConstructorArgs(configuration, environment, services, context))
+    {
+    }
+
     /// <summary>
     ///     存储所有已安装的Godot架构扩展组件列表
     ///     用于在架构销毁时正确清理所有扩展资源
@@ -44,10 +51,41 @@ public abstract class AbstractArchitecture(
     private bool _destroyed;
 
     /// <summary>
+    ///     使用已解析的构造参数继续初始化基类。
+    /// </summary>
+    private AbstractArchitecture(ResolvedConstructorArgs args)
+        : base(args.Configuration, args.Environment, args.Services, args.Context)
+    {
+    }
+
+    /// <summary>
     ///     获取架构根节点。如果尚未初始化或已被销毁，则抛出异常。
     /// </summary>
     /// <exception cref="InvalidOperationException">当架构未准备就绪时抛出。</exception>
     protected Node ArchitectureRoot => _anchor ?? throw new InvalidOperationException("Architecture root not ready");
+
+    /// <summary>
+    ///     统一解析 Godot 架构构造参数，确保服务实例与默认上下文共享同一容器。
+    /// </summary>
+    private static ResolvedConstructorArgs ResolveConstructorArgs(
+        IArchitectureConfiguration? configuration,
+        IEnvironment? environment,
+        IArchitectureServices? services,
+        IArchitectureContext? context)
+    {
+        var resolvedServices = services ?? new ArchitectureServices();
+        var resolvedContext = context ?? new GodotArchitectureContext(new ArchitectureContext(resolvedServices.Container));
+        return new ResolvedConstructorArgs(configuration, environment, resolvedServices, resolvedContext);
+    }
+
+    /// <summary>
+    ///     承载构造期间已解析的服务与上下文。
+    /// </summary>
+    private sealed record ResolvedConstructorArgs(
+        IArchitectureConfiguration? Configuration,
+        IEnvironment? Environment,
+        IArchitectureServices Services,
+        IArchitectureContext Context);
 
 
     /// <summary>

--- a/GFramework.Godot/Architectures/GodotArchitectureContext.cs
+++ b/GFramework.Godot/Architectures/GodotArchitectureContext.cs
@@ -18,6 +18,10 @@ namespace GFramework.Godot.Architectures;
 /// <summary>
 ///     为 Godot 架构上下文增加主线程同步 CQRS 保护，避免线程亲和 API 被 legacy 同步 bridge 静默切到线程池执行。
 /// </summary>
+/// <remarks>
+///     当调用发生在 Godot 主线程时，该包装器会拒绝同步 CQRS 入口并显式提示对应的异步迁移路径，
+///     以避免节点、场景树、UI 路由和暂停处理器在错误线程上运行。
+/// </remarks>
 internal sealed class GodotArchitectureContext(
     IArchitectureContext innerContext,
     Func<bool>? shouldGuard = null)
@@ -28,89 +32,122 @@ internal sealed class GodotArchitectureContext(
 
     private readonly Func<bool> _shouldGuard = shouldGuard ?? ShouldGuardSyncCqrsOnCurrentThread;
 
+    /// <inheritdoc />
     public TService GetService<TService>() where TService : class
     {
         return _innerContext.GetService<TService>();
     }
 
+    /// <inheritdoc />
     public IReadOnlyList<TService> GetServices<TService>() where TService : class
     {
         return _innerContext.GetServices<TService>();
     }
 
+    /// <inheritdoc />
     public TSystem GetSystem<TSystem>() where TSystem : class, ISystem
     {
         return _innerContext.GetSystem<TSystem>();
     }
 
+    /// <inheritdoc />
     public IReadOnlyList<TSystem> GetSystems<TSystem>() where TSystem : class, ISystem
     {
         return _innerContext.GetSystems<TSystem>();
     }
 
+    /// <inheritdoc />
     public TModel GetModel<TModel>() where TModel : class, IModel
     {
         return _innerContext.GetModel<TModel>();
     }
 
+    /// <inheritdoc />
     public IReadOnlyList<TModel> GetModels<TModel>() where TModel : class, IModel
     {
         return _innerContext.GetModels<TModel>();
     }
 
+    /// <inheritdoc />
     public TUtility GetUtility<TUtility>() where TUtility : class, IUtility
     {
         return _innerContext.GetUtility<TUtility>();
     }
 
+    /// <inheritdoc />
     public IReadOnlyList<TUtility> GetUtilities<TUtility>() where TUtility : class, IUtility
     {
         return _innerContext.GetUtilities<TUtility>();
     }
 
+    /// <inheritdoc />
     public IReadOnlyList<TService> GetServicesByPriority<TService>() where TService : class
     {
         return _innerContext.GetServicesByPriority<TService>();
     }
 
+    /// <inheritdoc />
     public IReadOnlyList<TSystem> GetSystemsByPriority<TSystem>() where TSystem : class, ISystem
     {
         return _innerContext.GetSystemsByPriority<TSystem>();
     }
 
+    /// <inheritdoc />
     public IReadOnlyList<TModel> GetModelsByPriority<TModel>() where TModel : class, IModel
     {
         return _innerContext.GetModelsByPriority<TModel>();
     }
 
+    /// <inheritdoc />
     public IReadOnlyList<TUtility> GetUtilitiesByPriority<TUtility>() where TUtility : class, IUtility
     {
         return _innerContext.GetUtilitiesByPriority<TUtility>();
     }
 
+    /// <summary>
+    ///     拦截旧版同步命令入口，并在 Godot 主线程保护启用时拒绝继续派发。
+    /// </summary>
+    /// <param name="command">要发送的命令。</param>
+    /// <exception cref="InvalidOperationException">当当前线程不允许同步 CQRS 调用时抛出。</exception>
     public void SendCommand(ICommand command)
     {
         GuardSyncCqrs(nameof(SendCommand));
         _innerContext.SendCommand(command);
     }
 
+    /// <summary>
+    ///     拦截旧版同步命令入口，并在 Godot 主线程保护启用时拒绝继续派发。
+    /// </summary>
+    /// <typeparam name="TResult">命令结果类型。</typeparam>
+    /// <param name="command">要发送的命令。</param>
+    /// <returns>命令结果。</returns>
+    /// <exception cref="InvalidOperationException">当当前线程不允许同步 CQRS 调用时抛出。</exception>
     public TResult SendCommand<TResult>(ICommand<TResult> command)
     {
         GuardSyncCqrs(nameof(SendCommand));
         return _innerContext.SendCommand(command);
     }
 
+    /// <summary>
+    ///     拦截新版同步 CQRS 命令入口，并在 Godot 主线程保护启用时拒绝继续派发。
+    /// </summary>
+    /// <typeparam name="TResponse">命令响应类型。</typeparam>
+    /// <param name="command">要发送的命令。</param>
+    /// <returns>命令结果。</returns>
+    /// <exception cref="InvalidOperationException">当当前线程不允许同步 CQRS 调用时抛出。</exception>
     public TResponse SendCommand<TResponse>(GFramework.Cqrs.Abstractions.Cqrs.Command.ICommand<TResponse> command)
     {
         GuardSyncCqrs(nameof(SendCommand));
         return _innerContext.SendCommand(command);
     }
 
+    /// <inheritdoc />
     public Task SendCommandAsync(IAsyncCommand command)
     {
         return _innerContext.SendCommandAsync(command);
     }
 
+    /// <inheritdoc />
     public ValueTask<TResponse> SendCommandAsync<TResponse>(
         GFramework.Cqrs.Abstractions.Cqrs.Command.ICommand<TResponse> command,
         CancellationToken cancellationToken = default)
@@ -118,28 +155,45 @@ internal sealed class GodotArchitectureContext(
         return _innerContext.SendCommandAsync(command, cancellationToken);
     }
 
+    /// <inheritdoc />
     public Task<TResult> SendCommandAsync<TResult>(IAsyncCommand<TResult> command)
     {
         return _innerContext.SendCommandAsync(command);
     }
 
+    /// <summary>
+    ///     拦截旧版同步查询入口，并在 Godot 主线程保护启用时拒绝继续派发。
+    /// </summary>
+    /// <typeparam name="TResult">查询结果类型。</typeparam>
+    /// <param name="query">要发送的查询。</param>
+    /// <returns>查询结果。</returns>
+    /// <exception cref="InvalidOperationException">当当前线程不允许同步 CQRS 调用时抛出。</exception>
     public TResult SendQuery<TResult>(IQuery<TResult> query)
     {
         GuardSyncCqrs(nameof(SendQuery));
         return _innerContext.SendQuery(query);
     }
 
+    /// <summary>
+    ///     拦截新版同步 CQRS 查询入口，并在 Godot 主线程保护启用时拒绝继续派发。
+    /// </summary>
+    /// <typeparam name="TResponse">查询响应类型。</typeparam>
+    /// <param name="query">要发送的查询。</param>
+    /// <returns>查询结果。</returns>
+    /// <exception cref="InvalidOperationException">当当前线程不允许同步 CQRS 调用时抛出。</exception>
     public TResponse SendQuery<TResponse>(GFramework.Cqrs.Abstractions.Cqrs.Query.IQuery<TResponse> query)
     {
         GuardSyncCqrs(nameof(SendQuery));
         return _innerContext.SendQuery(query);
     }
 
+    /// <inheritdoc />
     public Task<TResult> SendQueryAsync<TResult>(IAsyncQuery<TResult> query)
     {
         return _innerContext.SendQueryAsync(query);
     }
 
+    /// <inheritdoc />
     public ValueTask<TResponse> SendQueryAsync<TResponse>(
         GFramework.Cqrs.Abstractions.Cqrs.Query.IQuery<TResponse> query,
         CancellationToken cancellationToken = default)
@@ -147,31 +201,37 @@ internal sealed class GodotArchitectureContext(
         return _innerContext.SendQueryAsync(query, cancellationToken);
     }
 
+    /// <inheritdoc />
     public void SendEvent<TEvent>() where TEvent : new()
     {
         _innerContext.SendEvent<TEvent>();
     }
 
+    /// <inheritdoc />
     public void SendEvent<TEvent>(TEvent e) where TEvent : class
     {
         _innerContext.SendEvent(e);
     }
 
+    /// <inheritdoc />
     public IUnRegister RegisterEvent<TEvent>(Action<TEvent> handler)
     {
         return _innerContext.RegisterEvent(handler);
     }
 
+    /// <inheritdoc />
     public void UnRegisterEvent<TEvent>(Action<TEvent> onEvent)
     {
         _innerContext.UnRegisterEvent(onEvent);
     }
 
+    /// <inheritdoc />
     public IEnvironment GetEnvironment()
     {
         return _innerContext.GetEnvironment();
     }
 
+    /// <inheritdoc />
     public ValueTask<TResponse> SendRequestAsync<TResponse>(
         IRequest<TResponse> request,
         CancellationToken cancellationToken = default)
@@ -179,12 +239,20 @@ internal sealed class GodotArchitectureContext(
         return _innerContext.SendRequestAsync(request, cancellationToken);
     }
 
+    /// <summary>
+    ///     拦截同步 CQRS request 入口，并在 Godot 主线程保护启用时拒绝继续派发。
+    /// </summary>
+    /// <typeparam name="TResponse">请求响应类型。</typeparam>
+    /// <param name="request">要发送的请求。</param>
+    /// <returns>请求结果。</returns>
+    /// <exception cref="InvalidOperationException">当当前线程不允许同步 CQRS 调用时抛出。</exception>
     public TResponse SendRequest<TResponse>(IRequest<TResponse> request)
     {
         GuardSyncCqrs(nameof(SendRequest));
         return _innerContext.SendRequest(request);
     }
 
+    /// <inheritdoc />
     public ValueTask PublishAsync<TNotification>(
         TNotification notification,
         CancellationToken cancellationToken = default)
@@ -193,6 +261,7 @@ internal sealed class GodotArchitectureContext(
         return _innerContext.PublishAsync(notification, cancellationToken);
     }
 
+    /// <inheritdoc />
     public IAsyncEnumerable<TResponse> CreateStream<TResponse>(
         IStreamRequest<TResponse> request,
         CancellationToken cancellationToken = default)
@@ -200,12 +269,14 @@ internal sealed class GodotArchitectureContext(
         return _innerContext.CreateStream(request, cancellationToken);
     }
 
+    /// <inheritdoc />
     public ValueTask SendAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
         where TCommand : IRequest<Unit>
     {
         return _innerContext.SendAsync(command, cancellationToken);
     }
 
+    /// <inheritdoc />
     public ValueTask<TResponse> SendAsync<TResponse>(
         IRequest<TResponse> command,
         CancellationToken cancellationToken = default)
@@ -218,10 +289,17 @@ internal sealed class GodotArchitectureContext(
         if (!_shouldGuard())
             return;
 
+        var asyncAlternative = apiName switch
+        {
+            nameof(SendQuery) => "Use SendQueryAsync(...), SendAsync(...), or RunCommandCoroutine(...) instead.",
+            nameof(SendRequest) => "Use SendRequestAsync(...), SendAsync(...), or RunCommandCoroutine(...) instead.",
+            _ => "Use SendCommandAsync(...), SendAsync(...), or RunCommandCoroutine(...) instead."
+        };
+
         throw new InvalidOperationException(
             $"Godot main-thread synchronous CQRS call '{apiName}' is not allowed. " +
             "Legacy synchronous CQRS dispatch may execute handlers on a worker thread, which can break thread-affine Godot APIs " +
-            "such as Node, SceneTree, UI routing, and pause handlers. Use SendAsync(...), SendCommandAsync(...), or RunCommandCoroutine(...) instead.");
+            $"such as Node, SceneTree, UI routing, and pause handlers. {asyncAlternative}");
     }
 
     private static bool ShouldGuardSyncCqrsOnCurrentThread()

--- a/GFramework.Godot/Architectures/GodotArchitectureContext.cs
+++ b/GFramework.Godot/Architectures/GodotArchitectureContext.cs
@@ -1,0 +1,231 @@
+// Copyright (c) 2025-2026 GeWuYou
+// SPDX-License-Identifier: Apache-2.0
+
+using GFramework.Core.Abstractions.Architectures;
+using GFramework.Core.Abstractions.Command;
+using GFramework.Core.Abstractions.Environment;
+using GFramework.Core.Abstractions.Events;
+using GFramework.Core.Abstractions.Model;
+using GFramework.Core.Abstractions.Query;
+using GFramework.Core.Abstractions.Systems;
+using GFramework.Core.Abstractions.Utility;
+using GFramework.Cqrs.Abstractions.Cqrs;
+using Godot;
+using ICommand = GFramework.Core.Abstractions.Command.ICommand;
+
+namespace GFramework.Godot.Architectures;
+
+/// <summary>
+///     为 Godot 架构上下文增加主线程同步 CQRS 保护，避免线程亲和 API 被 legacy 同步 bridge 静默切到线程池执行。
+/// </summary>
+internal sealed class GodotArchitectureContext(
+    IArchitectureContext innerContext,
+    Func<bool>? shouldGuard = null)
+    : IArchitectureContext
+{
+    private readonly IArchitectureContext _innerContext =
+        innerContext ?? throw new ArgumentNullException(nameof(innerContext));
+
+    private readonly Func<bool> _shouldGuard = shouldGuard ?? ShouldGuardSyncCqrsOnCurrentThread;
+
+    public TService GetService<TService>() where TService : class
+    {
+        return _innerContext.GetService<TService>();
+    }
+
+    public IReadOnlyList<TService> GetServices<TService>() where TService : class
+    {
+        return _innerContext.GetServices<TService>();
+    }
+
+    public TSystem GetSystem<TSystem>() where TSystem : class, ISystem
+    {
+        return _innerContext.GetSystem<TSystem>();
+    }
+
+    public IReadOnlyList<TSystem> GetSystems<TSystem>() where TSystem : class, ISystem
+    {
+        return _innerContext.GetSystems<TSystem>();
+    }
+
+    public TModel GetModel<TModel>() where TModel : class, IModel
+    {
+        return _innerContext.GetModel<TModel>();
+    }
+
+    public IReadOnlyList<TModel> GetModels<TModel>() where TModel : class, IModel
+    {
+        return _innerContext.GetModels<TModel>();
+    }
+
+    public TUtility GetUtility<TUtility>() where TUtility : class, IUtility
+    {
+        return _innerContext.GetUtility<TUtility>();
+    }
+
+    public IReadOnlyList<TUtility> GetUtilities<TUtility>() where TUtility : class, IUtility
+    {
+        return _innerContext.GetUtilities<TUtility>();
+    }
+
+    public IReadOnlyList<TService> GetServicesByPriority<TService>() where TService : class
+    {
+        return _innerContext.GetServicesByPriority<TService>();
+    }
+
+    public IReadOnlyList<TSystem> GetSystemsByPriority<TSystem>() where TSystem : class, ISystem
+    {
+        return _innerContext.GetSystemsByPriority<TSystem>();
+    }
+
+    public IReadOnlyList<TModel> GetModelsByPriority<TModel>() where TModel : class, IModel
+    {
+        return _innerContext.GetModelsByPriority<TModel>();
+    }
+
+    public IReadOnlyList<TUtility> GetUtilitiesByPriority<TUtility>() where TUtility : class, IUtility
+    {
+        return _innerContext.GetUtilitiesByPriority<TUtility>();
+    }
+
+    public void SendCommand(ICommand command)
+    {
+        GuardSyncCqrs(nameof(SendCommand));
+        _innerContext.SendCommand(command);
+    }
+
+    public TResult SendCommand<TResult>(ICommand<TResult> command)
+    {
+        GuardSyncCqrs(nameof(SendCommand));
+        return _innerContext.SendCommand(command);
+    }
+
+    public TResponse SendCommand<TResponse>(GFramework.Cqrs.Abstractions.Cqrs.Command.ICommand<TResponse> command)
+    {
+        GuardSyncCqrs(nameof(SendCommand));
+        return _innerContext.SendCommand(command);
+    }
+
+    public Task SendCommandAsync(IAsyncCommand command)
+    {
+        return _innerContext.SendCommandAsync(command);
+    }
+
+    public ValueTask<TResponse> SendCommandAsync<TResponse>(
+        GFramework.Cqrs.Abstractions.Cqrs.Command.ICommand<TResponse> command,
+        CancellationToken cancellationToken = default)
+    {
+        return _innerContext.SendCommandAsync(command, cancellationToken);
+    }
+
+    public Task<TResult> SendCommandAsync<TResult>(IAsyncCommand<TResult> command)
+    {
+        return _innerContext.SendCommandAsync(command);
+    }
+
+    public TResult SendQuery<TResult>(IQuery<TResult> query)
+    {
+        GuardSyncCqrs(nameof(SendQuery));
+        return _innerContext.SendQuery(query);
+    }
+
+    public TResponse SendQuery<TResponse>(GFramework.Cqrs.Abstractions.Cqrs.Query.IQuery<TResponse> query)
+    {
+        GuardSyncCqrs(nameof(SendQuery));
+        return _innerContext.SendQuery(query);
+    }
+
+    public Task<TResult> SendQueryAsync<TResult>(IAsyncQuery<TResult> query)
+    {
+        return _innerContext.SendQueryAsync(query);
+    }
+
+    public ValueTask<TResponse> SendQueryAsync<TResponse>(
+        GFramework.Cqrs.Abstractions.Cqrs.Query.IQuery<TResponse> query,
+        CancellationToken cancellationToken = default)
+    {
+        return _innerContext.SendQueryAsync(query, cancellationToken);
+    }
+
+    public void SendEvent<TEvent>() where TEvent : new()
+    {
+        _innerContext.SendEvent<TEvent>();
+    }
+
+    public void SendEvent<TEvent>(TEvent e) where TEvent : class
+    {
+        _innerContext.SendEvent(e);
+    }
+
+    public IUnRegister RegisterEvent<TEvent>(Action<TEvent> handler)
+    {
+        return _innerContext.RegisterEvent(handler);
+    }
+
+    public void UnRegisterEvent<TEvent>(Action<TEvent> onEvent)
+    {
+        _innerContext.UnRegisterEvent(onEvent);
+    }
+
+    public IEnvironment GetEnvironment()
+    {
+        return _innerContext.GetEnvironment();
+    }
+
+    public ValueTask<TResponse> SendRequestAsync<TResponse>(
+        IRequest<TResponse> request,
+        CancellationToken cancellationToken = default)
+    {
+        return _innerContext.SendRequestAsync(request, cancellationToken);
+    }
+
+    public TResponse SendRequest<TResponse>(IRequest<TResponse> request)
+    {
+        GuardSyncCqrs(nameof(SendRequest));
+        return _innerContext.SendRequest(request);
+    }
+
+    public ValueTask PublishAsync<TNotification>(
+        TNotification notification,
+        CancellationToken cancellationToken = default)
+        where TNotification : INotification
+    {
+        return _innerContext.PublishAsync(notification, cancellationToken);
+    }
+
+    public IAsyncEnumerable<TResponse> CreateStream<TResponse>(
+        IStreamRequest<TResponse> request,
+        CancellationToken cancellationToken = default)
+    {
+        return _innerContext.CreateStream(request, cancellationToken);
+    }
+
+    public ValueTask SendAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
+        where TCommand : IRequest<Unit>
+    {
+        return _innerContext.SendAsync(command, cancellationToken);
+    }
+
+    public ValueTask<TResponse> SendAsync<TResponse>(
+        IRequest<TResponse> command,
+        CancellationToken cancellationToken = default)
+    {
+        return _innerContext.SendAsync(command, cancellationToken);
+    }
+
+    private void GuardSyncCqrs(string apiName)
+    {
+        if (!_shouldGuard())
+            return;
+
+        throw new InvalidOperationException(
+            $"Godot main-thread synchronous CQRS call '{apiName}' is not allowed. " +
+            "Legacy synchronous CQRS dispatch may execute handlers on a worker thread, which can break thread-affine Godot APIs " +
+            "such as Node, SceneTree, UI routing, and pause handlers. Use SendAsync(...), SendCommandAsync(...), or RunCommandCoroutine(...) instead.");
+    }
+
+    private static bool ShouldGuardSyncCqrsOnCurrentThread()
+    {
+        return Engine.GetMainLoop() is SceneTree && GodotThread.IsMainThread();
+    }
+}

--- a/GFramework.Godot/README.md
+++ b/GFramework.Godot/README.md
@@ -133,6 +133,25 @@ Godot 上。
 
 不要把这些宿主实现误写成 `Game` 模块的默认行为。
 
+### 5. Godot 主线程不要走同步 CQRS
+
+`AbstractArchitecture` 现在会为默认上下文启用 Godot 主线程同步 CQRS 保护。
+
+如果当前进程存在 `SceneTree`，且调用发生在 Godot 主线程上：
+
+- 不要调用同步 `SendRequest(...)`
+- 不要调用同步 `SendCommand(...)`
+- 不要调用同步 `SendQuery(...)`
+
+这些入口会命中 legacy 同步 bridge，而 bridge 可能把 handler 执行切到工作线程，进而让 `Node`、`SceneTree`、`UiRoot`、
+暂停处理器等线程亲和 Godot API 在非主线程运行。
+
+在 Godot 节点、UI、输入和场景回调里，改用：
+
+- `SendAsync(...)`
+- `SendCommandAsync(...)`
+- `RunCommandCoroutine(...)`
+
 ## 典型接入方式
 
 - 架构侧保持普通模块注册，再按需挂接 Godot 宿主

--- a/ai-plan/public/README.md
+++ b/ai-plan/public/README.md
@@ -42,6 +42,10 @@ help the current worktree land on the right recovery documents without scanning 
   - Purpose: establish the shared input abstraction, default binding runtime, and Godot InputMap integration path.
   - Tracking: `ai-plan/public/input-system-godot-integration/todos/input-system-godot-integration-tracking.md`
   - Trace: `ai-plan/public/input-system-godot-integration/traces/input-system-godot-integration-trace.md`
+- `godot-cqrs-main-thread-guard`
+  - Purpose: triage the active PR review for Godot main-thread CQRS guard work and keep the minimal recovery entrypoint for documentation, guard-message, and regression-test fixes.
+  - Tracking: `ai-plan/public/godot-cqrs-main-thread-guard/todos/godot-cqrs-main-thread-guard-tracking.md`
+  - Trace: `ai-plan/public/godot-cqrs-main-thread-guard/traces/godot-cqrs-main-thread-guard-trace.md`
 
 ## Worktree To Active Topic Map
 
@@ -62,6 +66,9 @@ help the current worktree land on the right recovery documents without scanning 
 - Branch: `feat/input-system-godot-integration`
   - Worktree hint: `GFramework-input-system-godot-integration`
   - Priority 1: `input-system-godot-integration`
+- Branch: `fix/godot-cqrs-main-thread-guard`
+  - Worktree hint: `GFramework`
+  - Priority 1: `godot-cqrs-main-thread-guard`
 - Branch: `docs/sdk-update-documentation`
   - Worktree hint: `GFramework-update-documentation`
   - Priority 1: `documentation-full-coverage-governance`

--- a/ai-plan/public/godot-cqrs-main-thread-guard/todos/godot-cqrs-main-thread-guard-tracking.md
+++ b/ai-plan/public/godot-cqrs-main-thread-guard/todos/godot-cqrs-main-thread-guard-tracking.md
@@ -1,0 +1,69 @@
+<!--
+Copyright (c) 2025-2026 GeWuYou
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Godot CQRS 主线程保护跟踪
+
+## 目标
+
+围绕 `fix/godot-cqrs-main-thread-guard` 当前 PR 的 AI review 结果，完成仍然有效的文档、提示文案与回归测试修复。
+
+## 当前恢复点
+
+- 恢复点编号：`GODOT-CQRS-GUARD-RP-001`
+- 当前阶段：`PR review triage`
+- 当前 PR 锚点：`PR #366（OPEN，2026-06-19 复核）`
+- 当前结论：
+  - `$gframework-pr-review` 已确认当前 PR 最新 head 上仍有 `6` 条 AI review open threads。
+  - 本地复核后仍然有效的问题集中在 `GFramework.Godot` 与 `GFramework.Godot.Tests`，不涉及新的 CI 失败测试。
+  - 需要修复的有效问题包括：
+    - `AbstractArchitecture` 受保护构造函数缺少完整 XML 契约说明
+    - `GodotArchitectureContext` 的公开接口实现缺少 XML 文档
+    - 同步查询守卫提示缺少 `SendQueryAsync(...)`
+    - 测试公开入口缺少 XML 注释，且存在 `Assert.Throws*` 返回值非空的冗余断言
+
+## 当前活跃事实
+
+- 当前分支：`fix/godot-cqrs-main-thread-guard`
+- 当前工作面：
+  - `GFramework.Godot/Architectures/AbstractArchitecture.cs`
+  - `GFramework.Godot/Architectures/GodotArchitectureContext.cs`
+  - `GFramework.Godot.Tests/Architectures/AbstractArchitectureModuleInstallationTests.cs`
+- 当前 review 真值：
+  - CodeRabbit open threads：`4`
+  - Greptile open threads：`2`
+  - failed checks：`Docstring Coverage` warning、`MegaLinter` success with warnings
+  - 测试报告：`2299 passed / 0 failed`
+
+## 当前风险
+
+- 若只补接口文档而不修正守卫文案，`SendQuery(...)` 的调用方仍会收到不完整迁移指引。
+- 若测试继续保留冗余断言而不覆盖同步查询提示，review 线程即使重新跑也可能继续成立。
+
+## 最近权威验证
+
+- `python3 .agents/skills/gframework-pr-review/scripts/fetch_current_pr_review.py --json-output /tmp/gframework-current-pr-review.json`
+  - 结果：通过
+  - 备注：确认当前分支对应 `PR #366`，并抓到 `6` 条 latest-head open threads
+- `python3 scripts/license-header.py --check --paths ai-plan/public/README.md ai-plan/public/godot-cqrs-main-thread-guard/todos/godot-cqrs-main-thread-guard-tracking.md ai-plan/public/godot-cqrs-main-thread-guard/traces/godot-cqrs-main-thread-guard-trace.md GFramework.Godot/Architectures/AbstractArchitecture.cs GFramework.Godot/Architectures/GodotArchitectureContext.cs GFramework.Godot.Tests/Architectures/AbstractArchitectureModuleInstallationTests.cs`
+  - 结果：通过
+  - 备注：本轮新增与修改文件均保留 Apache-2.0 头
+- `git diff --check`
+  - 结果：通过
+  - 备注：当前 patch 未引入 whitespace 或 patch 格式问题
+- `dotnet build GFramework.Godot/GFramework.Godot.csproj -c Release`
+  - 结果：通过，`0 warning / 0 error`
+  - 备注：覆盖本轮运行时代码改动
+- `dotnet build GFramework.Godot.Tests/GFramework.Godot.Tests.csproj -c Release`
+  - 结果：通过，`0 warning / 0 error`
+  - 备注：覆盖本轮测试代码改动
+- `dotnet test GFramework.Godot.Tests/GFramework.Godot.Tests.csproj -c Release --filter "FullyQualifiedName~AbstractArchitectureModuleInstallationTests" -m:1`
+  - 结果：失败
+  - 备注：`VSTest` 在 `net10.0` 下直接报告 `Test host process crashed`，属于当前测试宿主运行时问题，尚未拿到用例级失败输出
+
+## 下一推荐步骤
+
+1. 提交本轮已验证的 runtime / test 文档修复。
+2. 推送后重新执行 `$gframework-pr-review`，确认当前 open threads 是否只剩 stale 信号。
+3. 若仍需测试级证明，再单独排查 `GFramework.Godot.Tests` 的 `net10.0` test host 崩溃原因。

--- a/ai-plan/public/godot-cqrs-main-thread-guard/todos/godot-cqrs-main-thread-guard-tracking.md
+++ b/ai-plan/public/godot-cqrs-main-thread-guard/todos/godot-cqrs-main-thread-guard-tracking.md
@@ -59,11 +59,17 @@ SPDX-License-Identifier: Apache-2.0
   - 结果：通过，`0 warning / 0 error`
   - 备注：覆盖本轮测试代码改动
 - `dotnet test GFramework.Godot.Tests/GFramework.Godot.Tests.csproj -c Release --filter "FullyQualifiedName~AbstractArchitectureModuleInstallationTests" -m:1`
-  - 结果：失败
-  - 备注：`VSTest` 在 `net10.0` 下直接报告 `Test host process crashed`，属于当前测试宿主运行时问题，尚未拿到用例级失败输出
+  - 结果：已修复后通过
+  - 备注：根因是 `AbstractArchitecture_ShouldUseGodotContextWrapper_ByDefault` 在无 Godot 宿主的测试环境里调用 `Initialize()`，触发 `Engine.GetMainLoop()` 原生路径并导致 test host 崩溃
+- `dotnet test GFramework.Godot.Tests/GFramework.Godot.Tests.csproj -c Release --filter "FullyQualifiedName~GFramework.Godot.Tests.Architectures.AbstractArchitectureModuleInstallationTests.AbstractArchitecture_ShouldUseGodotContextWrapper_ByDefault"`
+  - 结果：通过
+  - 备注：调整为仅验证默认 `Context` 包装后，该单测不再依赖 Godot 原生宿主
+- `dotnet test GFramework.Godot.Tests/GFramework.Godot.Tests.csproj -c Release`
+  - 结果：通过，`83 passed / 0 failed`
+  - 备注：确认 `GFramework.Godot.Tests` 的全量 `net10.0` 测试已恢复正常退出
 
 ## 下一推荐步骤
 
 1. 提交本轮已验证的 runtime / test 文档修复。
 2. 推送后重新执行 `$gframework-pr-review`，确认当前 open threads 是否只剩 stale 信号。
-3. 若仍需测试级证明，再单独排查 `GFramework.Godot.Tests` 的 `net10.0` test host 崩溃原因。
+3. 若 CI 仍出现 Godot 测试宿主问题，再检查是否有新的测试在无宿主环境里直接调用依赖 `Engine.GetMainLoop()` 的初始化路径。

--- a/ai-plan/public/godot-cqrs-main-thread-guard/traces/godot-cqrs-main-thread-guard-trace.md
+++ b/ai-plan/public/godot-cqrs-main-thread-guard/traces/godot-cqrs-main-thread-guard-trace.md
@@ -46,4 +46,7 @@ SPDX-License-Identifier: Apache-2.0
   - `git diff --check`：通过
   - `dotnet build GFramework.Godot/GFramework.Godot.csproj -c Release`：通过，`0 warning / 0 error`
   - `dotnet build GFramework.Godot.Tests/GFramework.Godot.Tests.csproj -c Release`：通过，`0 warning / 0 error`
-  - `dotnet test ... AbstractArchitectureModuleInstallationTests`：失败，`Test host process crashed`
+  - 初次 `dotnet test ... AbstractArchitectureModuleInstallationTests`：失败，`Test host process crashed`
+  - 复核根因：`AbstractArchitecture_ShouldUseGodotContextWrapper_ByDefault` 在无 Godot 宿主环境里调用 `Initialize()`，执行 `Engine.GetMainLoop()` 时直接打崩 test host
+  - 修复后 `dotnet test ... AbstractArchitecture_ShouldUseGodotContextWrapper_ByDefault`：通过
+  - 修复后 `dotnet test GFramework.Godot.Tests/GFramework.Godot.Tests.csproj -c Release`：通过，`83 passed / 0 failed`

--- a/ai-plan/public/godot-cqrs-main-thread-guard/traces/godot-cqrs-main-thread-guard-trace.md
+++ b/ai-plan/public/godot-cqrs-main-thread-guard/traces/godot-cqrs-main-thread-guard-trace.md
@@ -1,0 +1,49 @@
+<!--
+Copyright (c) 2025-2026 GeWuYou
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Godot CQRS 主线程保护追踪
+
+## 当前恢复摘要
+
+- 当前恢复点：`GODOT-CQRS-GUARD-RP-001`
+- 当前日期：`2026-06-19`
+- 当前分支：`fix/godot-cqrs-main-thread-guard`
+- 当前 PR：`PR #366（OPEN）`
+- 当前目标：
+  - 用 `$gframework-pr-review` 获取当前 PR 的最新 AI review 真值
+  - 只修复本地仍成立的文档、守卫提示与测试问题
+  - 在不扩大写面的前提下完成最小验证并形成可恢复入口
+
+## 2026-06-19
+
+### 阶段：PR #366 review triage（GODOT-CQRS-GUARD-RP-001）
+
+- 先按技能流程执行 PR review 抓取脚本，确认当前分支对应 `PR #366`。
+- 当前抓取结果：
+  - latest-head open threads：`6`
+  - failed checks：`Docstring Coverage` warning
+  - MegaLinter：`Success with warnings`
+  - 测试汇总：`2299 passed / 0 failed`
+- 本地复核后认定仍然有效的问题：
+  - `AbstractArchitecture` 构造函数缺少参数与行为说明
+  - `GodotArchitectureContext` 公开接口实现缺少 XML 文档
+  - `GuardSyncCqrs` 对 `SendQuery(...)` 的异步替代方案提示不完整
+  - `AbstractArchitectureModuleInstallationTests` 中公开测试方法缺少 XML 注释，且存在冗余 `Is.Not.Null` 断言
+- 本轮计划写面：
+  - `GFramework.Godot/Architectures/AbstractArchitecture.cs`
+  - `GFramework.Godot/Architectures/GodotArchitectureContext.cs`
+  - `GFramework.Godot.Tests/Architectures/AbstractArchitectureModuleInstallationTests.cs`
+  - 当前 topic 的 `ai-plan/public/**` 恢复文档
+- 本轮已完成修复：
+  - 为 `AbstractArchitecture` 构造函数补齐参数与容器共享语义说明
+  - 为 `GodotArchitectureContext` 的公开接口实现补齐 `inheritdoc` / 行为说明
+  - 让同步守卫提示按 `SendCommand` / `SendQuery` / `SendRequest` 返回对应异步替代方案
+  - 为 `AbstractArchitectureModuleInstallationTests` 补 XML 文档，移除冗余非空断言，并新增 `SendQueryAsync(...)` 提示断言
+- 本轮验证摘要：
+  - `license-header --check`：通过
+  - `git diff --check`：通过
+  - `dotnet build GFramework.Godot/GFramework.Godot.csproj -c Release`：通过，`0 warning / 0 error`
+  - `dotnet build GFramework.Godot.Tests/GFramework.Godot.Tests.csproj -c Release`：通过，`0 warning / 0 error`
+  - `dotnet test ... AbstractArchitectureModuleInstallationTests`：失败，`Test host process crashed`

--- a/docs/zh-CN/godot/architecture.md
+++ b/docs/zh-CN/godot/architecture.md
@@ -127,6 +127,26 @@ public sealed class HudModule : AbstractGodotModule
 - 模块会在挂接节点前先完成框架侧注册
 - 只有等锚点真正 ready 后，才进入需要访问 Godot 节点 API 的附加阶段
 
+### Godot 主线程同步 CQRS 保护
+
+继承 `AbstractArchitecture` 且未自定义 `IArchitectureContext` 时，默认上下文会启用 Godot 主线程同步 CQRS guard。
+
+当满足下面两个条件时：
+
+1. 当前进程存在有效的 `SceneTree`
+2. 当前调用发生在 Godot 主线程
+
+同步 `SendRequest(...)`、同步 `SendCommand(...)`、同步 `SendQuery(...)` 会直接抛出明确异常，而不是继续走 legacy 同步 bridge。
+
+原因不是这些 API 本身必然错误，而是当前 legacy bridge 可能把 handler 执行切到工作线程；一旦 handler 内部触达
+`Node`、`SceneTree`、UI 路由、暂停处理器等线程亲和 Godot API，就会产生越线程调用。
+
+Godot 场景中的推荐入口是：
+
+- `SendAsync(...)`
+- `SendCommandAsync(...)`
+- `RunCommandCoroutine(...)`
+
 ### 销毁阶段
 
 `ArchitectureAnchor._ExitTree()` 会触发绑定好的退出回调，随后 `AbstractArchitecture` 会开始观察异步销毁流程：


### PR DESCRIPTION
- 新增 GodotArchitectureContext，在 Godot 主线程上阻止同步 CQRS 入口触发线程亲和风险
- 更新 AbstractArchitecture 默认上下文接线，让 Godot 架构自动启用同步 CQRS guard
- 补充 Godot 架构测试与文档，说明改用异步 SendAsync 或协程桥接

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新特性**
  * 为 Godot 主线程默认启用同步 CQRS 调用保护：当在主线程执行同步 `SendRequest/SendQuery/SendCommand` 时，将抛出明确异常，引导使用更安全的异步入口。
  * 默认架构上下文将自动包裹为 Godot 专用上下文以应用该保护与转发逻辑。

* **文档**
  * 更新使用指南与章节说明：在 Godot 场景回调中优先使用 `SendAsync/SendCommandAsync/RunCommandCoroutine`，避免同步调用带来的线程亲和风险。

* **测试**
  * 新增单元测试覆盖保护启用/失活时的行为差异与上下文默认包装效果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `GodotArchitectureContext`, a decorator for `IArchitectureContext` that intercepts synchronous CQRS entry points (`SendRequest`, `SendQuery`, `SendCommand`) and throws `InvalidOperationException` when invoked on the Godot main thread, guiding callers toward async alternatives. `AbstractArchitecture`'s constructor is refactored from a two-stage `this(ResolveConstructorArgs(...))` pattern so that the default context and default service container always share the same IoC container instance.

- Adds `GodotArchitectureContext` with a per-call `Func<bool>` guard (defaulting to `Engine.GetMainLoop() is SceneTree && GodotThread.IsMainThread()`) and per-API async guidance in the thrown exception message.
- Refactors `AbstractArchitecture` constructor to automatically wrap the default context in `GodotArchitectureContext`, ensuring the inner `ArchitectureContext` and `ArchitectureServices` share the same container.
- Adds three new tests covering guard-active throwing, guard-inactive forwarding, and default context type, plus documentation updates in both the module README and `docs/zh-CN`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the guard implementation is correct and no existing callers are silently broken.

The guard logic, message differentiation, and constructor container-sharing are all sound. Both previously open review threads have been resolved in this revision. The only remaining gap is minor test coverage omissions rather than runtime defects.

GFramework.Godot.Tests/Architectures/AbstractArchitectureModuleInstallationTests.cs — the forwarding test covers only SendRequest; SendQuery and SendCommand forwarding paths have no verification.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GFramework.Godot/Architectures/GodotArchitectureContext.cs | New decorator that guards sync CQRS entry points on the Godot main thread; guard messages correctly differentiate per-API async alternatives; all async paths pass through without interception. |
| GFramework.Godot/Architectures/AbstractArchitecture.cs | Constructor refactored from primary-constructor style to explicit protected constructor with ResolveConstructorArgs; correctly shares IoC container between ArchitectureServices and default GodotArchitectureContext. |
| GFramework.Godot.Tests/Architectures/AbstractArchitectureModuleInstallationTests.cs | New tests cover guard-active throwing for SendRequest/SendQuery, guard-inactive forwarding for SendRequest only, and default context wrapper type; SendCommand guard path has no test coverage. |
| GFramework.Godot/README.md | Added section 5 documenting Godot main-thread sync CQRS restrictions and recommended async alternatives; content is consistent with the guard implementation. |
| docs/zh-CN/godot/architecture.md | Added Godot main-thread sync CQRS protection section accurately describing the two trigger conditions and recommended async entry points. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Caller (Godot Node)
    participant GA as GodotArchitectureContext
    participant G as GuardSyncCqrs
    participant IC as Inner IArchitectureContext

    C->>GA: SendRequest / SendQuery / SendCommand (sync)
    GA->>G: _shouldGuard()
    alt Main thread + SceneTree active
        G-->>GA: true
        GA-->>C: throws InvalidOperationException
    else Off-thread or no SceneTree
        G-->>GA: false
        GA->>IC: forward call
        IC-->>GA: result
        GA-->>C: result
    end

    C->>GA: SendAsync / SendRequestAsync / SendQueryAsync / SendCommandAsync
    GA->>IC: forward directly (no guard)
    IC-->>GA: result
    GA-->>C: result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Caller (Godot Node)
    participant GA as GodotArchitectureContext
    participant G as GuardSyncCqrs
    participant IC as Inner IArchitectureContext

    C->>GA: SendRequest / SendQuery / SendCommand (sync)
    GA->>G: _shouldGuard()
    alt Main thread + SceneTree active
        G-->>GA: true
        GA-->>C: throws InvalidOperationException
    else Off-thread or no SceneTree
        G-->>GA: false
        GA->>IC: forward call
        IC-->>GA: result
        GA-->>C: result
    end

    C->>GA: SendAsync / SendRequestAsync / SendQueryAsync / SendCommandAsync
    GA->>IC: forward directly (no guard)
    IC-->>GA: result
    GA-->>C: result
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
GFramework.Godot.Tests/Architectures/AbstractArchitectureModuleInstallationTests.cs:50-57
The forwarding test only exercises `SendRequest` when the guard is inactive, leaving `SendQuery` and `SendCommand` forwarding paths untested. If a future refactor accidentally breaks the delegation for those two methods (e.g., by returning a default value instead of forwarding), this test would not catch it.

```suggestion
    public void GodotArchitectureContext_ShouldForwardSyncCqrsCalls_WhenGuardIsInactive()
    {
        var context = new GodotArchitectureContext(new ForwardingArchitectureContext(), () => false);

        var requestResult = context.SendRequest(new TestRequest());
        var queryResult = context.SendQuery(new TestLegacyQuery());

        Assert.Multiple(() =>
        {
            Assert.That(requestResult, Is.EqualTo("ok"));
            Assert.That(queryResult, Is.EqualTo("ok"));
        });
    }
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(godot-tests): 修复无宿主环境测试崩溃"](https://github.com/gewuyou/gframework/commit/de4e7c06680ccec4272535806e2579b6865da2b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34168537)</sub>

<!-- /greptile_comment -->